### PR TITLE
Typescript additions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -67,7 +67,9 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$.jsx_opening_element, $._entity_name],
     [$.jsx_opening_element, $._entity_name, $.type_parameter],
 
-    [$.type_reference]
+    [$.type_reference],
+
+    [$.export_statement, $.ambient_export_declaration]
   ]),
   rules: {
 
@@ -105,6 +107,12 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       seq('export', optional('default'), $.ambient_function),
       seq('export', 'default', $._expression, terminator()),
       seq('export', '=', $.identifier, terminator())
+    ),
+
+    // Exports that can appear in object types, namespace elements, modules, and interfaces
+    ambient_export_declaration: $ => seq(
+      'export',
+      $.ambient_function
     ),
 
     variable_declarator: ($, previous) => choice(
@@ -466,6 +474,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     _type_member: $ => prec.right(choice(
+      $.ambient_export_declaration,
       $.property_signature,
       $.call_signature,
       $.construct_signature,

--- a/grammar.js
+++ b/grammar.js
@@ -80,7 +80,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       seq('export', $.export_clause, terminator()),
       seq('export', $._declaration),
       seq('export', 'default', $.anonymous_class),
-      seq('export', 'default', $.ambient_function),
+      seq('export', optional('default'), $.ambient_function),
       seq('export', 'default', $._expression, terminator()),
       seq('export', '=', $.identifier, terminator())
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -270,7 +270,6 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ambient_namespace_body: $ => repeat1($.ambient_namespace_element),
 
     ambient_namespace_element: $ => seq(
-      optional('export'),
       choice(
         $.ambient_variable,
         $.lexical_declaration,
@@ -279,7 +278,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
         $.interface_declaration,
         $._ambient_enum,
         $.ambient_namespace,
-        $.import_alias
+        $.import_alias,
+        $.type_alias_declaration
       )
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -112,7 +112,14 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     // Exports that can appear in object types, namespace elements, modules, and interfaces
     ambient_export_declaration: $ => seq(
       'export',
-      $.ambient_function
+      choice(
+        $.ambient_variable,
+        $.ambient_function,
+        $.class,
+        $._ambient_enum,
+        $.ambient_namespace,
+        $.module,
+        $.type_alias_declaration)
     ),
 
     variable_declarator: ($, previous) => choice(
@@ -267,21 +274,18 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       '}'
     ),
 
-    ambient_namespace_body: $ => repeat1($.ambient_namespace_element),
-
-    ambient_namespace_element: $ => seq(
-      choice(
-        $.ambient_variable,
-        $.lexical_declaration,
-        $.ambient_function,
-        $.class,
-        $.interface_declaration,
-        $._ambient_enum,
-        $.ambient_namespace,
-        $.import_alias,
-        $.type_alias_declaration
-      )
-    ),
+    ambient_namespace_body: $ => repeat1(choice(
+      $.ambient_export_declaration,
+      $.ambient_variable,
+      $.lexical_declaration,
+      $.ambient_function,
+      $.class,
+      $.interface_declaration,
+      $._ambient_enum,
+      $.ambient_namespace,
+      $.import_alias,
+      $.type_alias_declaration
+    )),
 
     import_alias: $ => seq(
       'import',
@@ -419,6 +423,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.parenthesized_type,
       $.predefined_type,
       $.type_reference,
+      $.type_predicate,
       $.object_type,
       $.array_type,
       $.tuple_type,
@@ -427,6 +432,12 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.this_type,
       $.existential_type,
       $.literal_type
+    ),
+
+    type_predicate: $ => seq(
+      $.identifier,
+      'is',
+      $._type
     ),
 
     type_query: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -50,9 +50,9 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     [$.this_type, $.this_expression],
 
-    [$.required_parameter, $.entity_name],
-    [$._expression, $.required_parameter, $.entity_name],
-    [$._expression, $.entity_name],
+    [$.required_parameter, $._entity_name],
+    [$._expression, $.required_parameter, $._entity_name],
+    [$._expression, $._entity_name],
 
     [$.ambient_binding, $.variable_declarator],
 
@@ -62,10 +62,10 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     //               ^ parenthesized_type or function_type
     [$.parameter_identifier, $.predefined_type],
 
-    [$.entity_name, $.type_parameter],
+    [$._entity_name, $.type_parameter],
 
-    [$.jsx_opening_element, $.entity_name],
-    [$.jsx_opening_element, $.entity_name, $.type_parameter],
+    [$.jsx_opening_element, $._entity_name],
+    [$.jsx_opening_element, $._entity_name, $.type_parameter],
 
     [$.type_reference]
   ]),
@@ -242,7 +242,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     _ambient_enum: $ => $.enum_declaration,
 
     ambient_namespace: $ => seq(
-      'namespace', $.entity_name, '{', optional($.ambient_namespace_body), '}'
+      'namespace', $._entity_name, '{', optional($.ambient_namespace_body), '}'
     ),
 
     module: $ => seq(
@@ -279,11 +279,11 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       'import',
       $.identifier,
       '=',
-      $.entity_name,
+      $._entity_name,
       terminator()
     ),
 
-    entity_name: $ => prec.right(sepBy1('.', $.identifier)),
+    _entity_name: $ => prec.right(sepBy1('.', $.identifier)),
 
     ambient_binding: $ => seq(
       $.identifier,
@@ -423,7 +423,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     type_query: $ => seq(
       'typeof',
-      $.entity_name
+      $._entity_name
     ),
 
     literal_type: $ => choice($.number, $.string, $.true, $.false),
@@ -452,7 +452,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     type_reference: $ => seq(
-      $.entity_name,
+      $._entity_name,
       optional($.type_arguments)
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -216,10 +216,13 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       'module',
       choice($.string, $.identifier),
       '{',
-        repeat(choice(
-          $.import_statement,
-          $.export_statement,
-          $._declaration)),
+        repeat(seq(
+          choice(
+            $.import_statement,
+            $.export_statement,
+            $.ambient_function,
+            $._declaration),
+          optional(terminator()))),
       '}'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -184,7 +184,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
         $.ambient_function,
         $.class,
         $._ambient_enum,
-        $.ambient_namespace
+        $.ambient_namespace,
+        $.type_alias_declaration
       )
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -62,6 +62,12 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
   rules: {
 
     // Overrides
+    pair: ($, previous) => seq(
+      seq(
+        choice($.identifier, $.reserved_identifier, $.string, $.number, $.accessibility_modifier)),
+      ':',
+      $._expression
+    ),
 
     // Override import and export to support Flow 'import type' statements
     import_statement: ($, previous) => seq(
@@ -87,7 +93,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     variable_declarator: ($, previous) => choice(
       seq($.identifier, optional($.type_annotation), optional($._initializer)),
-      seq($.assignment_pattern, optional($.type_annotation), $._initializer)
+      seq($.destructuring_pattern, optional($.type_annotation), $._initializer)
     ),
 
 
@@ -518,7 +524,7 @@ function sepBy (sep, rule) {
 }
 
 function pattern ($) {
-  return choice($.identifier, $.assignment_pattern)
+  return choice($.identifier, $.destructuring_pattern)
 }
 
 function terminator () {

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -285,3 +285,21 @@ export interface Foo {
                       (identifier)
                       (type_arguments (type_reference (identifier)) (type_reference (identifier)))))))
                       (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)) (type_reference (identifier))))))))))))
+
+
+=================================
+Ambient type alias declarations in namespaces
+=================================
+
+declare namespace moment {
+  type formatFunction = () => string;
+}
+
+---
+
+(program
+  (ambient_declaration
+    (ambient_namespace
+      (identifier)
+      (ambient_namespace_body
+        (ambient_namespace_element (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type))))))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -250,4 +250,8 @@ foo as any as Array<number>
 
 ---
 
-(program (expression_statement (type_assertion (type_arguments (predefined_type)) (identifier))) (expression_statement (as_expression (as_expression (identifier) (predefined_type)) (type_reference (entity_name (identifier)) (type_arguments (predefined_type))))))
+(program
+  (expression_statement
+    (type_assertion (type_arguments (predefined_type)) (identifier)))
+  (expression_statement
+    (as_expression (as_expression (identifier) (predefined_type)) (type_reference (identifier) (type_arguments (predefined_type))))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -293,6 +293,13 @@ Ambient type alias declarations in namespaces
 
 declare namespace moment {
   type formatFunction = () => string;
+
+  export var x: string;
+  export class foo {
+
+  }
+  export function utc(): Moment;
+  export const enum Blah { Blaz, Bloz, Bleez }
 }
 
 ---
@@ -302,4 +309,5 @@ declare namespace moment {
     (ambient_namespace
       (identifier)
       (ambient_namespace_body
-        (ambient_namespace_element (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type))))))))
+      (ambient_namespace_element (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))) (ambient_namespace_element (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))) (ambient_namespace_element (ambient_export_declaration (class (identifier) (class_body)))) (ambient_namespace_element (ambient_export_declaration (ambient_function (identifier) (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))) (ambient_namespace_element (ambient_export_declaration (enum_declaration (identifier) (identifier) (identifier) (identifier))))))))
+

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -194,9 +194,25 @@ declare type IndexableType = string | number | Date | Array<string | number | Da
 Ambient module declarations
 ================================
 
-declare module Dexie {
+module Promise {
+    var on: {}
+    function resolve<R>(value?: Thenable<R>): Promise<R>;
 }
 
 ---
+(program
+  (module
+    (identifier)
+    (variable_declaration (variable_declarator
+      (identifier)
+      (type_annotation (object_type))))
+    (ambient_function
+      (identifier)
+      (call_signature
+        (type_parameters (type_parameter (identifier)))
+        (formal_parameters
+          (optional_parameter
+            (identifier)
+            (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))
+        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))
 
-(program (ambient_declaration (module (identifier))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -196,7 +196,7 @@ Ambient module declarations
 
 module Promise {
     var on: {}
-    function resolve<R>(value?: Thenable<R>): Promise<R>;
+    export function resolve<R>(value?: Thenable<R>): Promise<R>;
 }
 
 ---
@@ -206,7 +206,7 @@ module Promise {
     (variable_declaration (variable_declarator
       (identifier)
       (type_annotation (object_type))))
-    (ambient_function
+    (export_statement (ambient_function
       (identifier)
       (call_signature
         (type_parameters (type_parameter (identifier)))
@@ -214,5 +214,5 @@ module Promise {
           (optional_parameter
             (identifier)
             (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))
-        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))
+        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
 

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -189,3 +189,14 @@ declare type IndexableType = string | number | Date | Array<string | number | Da
             (type_reference
               (identifier)
               (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_reference (identifier)))))))))
+
+==================================
+Ambient module declarations
+================================
+
+declare module Dexie {
+}
+
+---
+
+(program (ambient_declaration (module (identifier))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -225,3 +225,29 @@ Accessibility modifiers as pair keywords
 ---
 
 (program (expression_statement (object (identifier) (identifier) (pair (accessibility_modifier) (identifier)))))
+
+=================================
+JSX and type assertions
+=================================
+
+<string>foo;
+
+a = <div className='b' tabIndex=1 />;
+b = <div>{ <string>a } <span>b</span> c</div>;
+
+---
+
+(program
+  (expression_statement (type_assertion (type_arguments (predefined_type)) (identifier))) (expression_statement (assignment (identifier) (jsx_self_closing_element (identifier) (jsx_attribute (identifier) (string)) (jsx_attribute (identifier) (number))))) (expression_statement (assignment (identifier) (jsx_element (jsx_opening_element (identifier)) (jsx_expression (type_assertion (type_arguments (predefined_type)) (identifier))) (jsx_text) (jsx_element (jsx_opening_element (identifier)) (jsx_text) (jsx_closing_element (identifier))) (jsx_text) (jsx_closing_element (identifier))))))
+
+=================================
+Type assertions
+=================================
+
+<string>foo;
+
+foo as any as Array<number>
+
+---
+
+(program (expression_statement (type_assertion (type_arguments (predefined_type)) (identifier))) (expression_statement (as_expression (as_expression (identifier) (predefined_type)) (type_reference (entity_name (identifier)) (type_arguments (predefined_type))))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -52,26 +52,22 @@ declare class Greeter {
     (ambient_namespace
       (identifier)
       (ambient_namespace_body
-        (ambient_namespace_element
-          (ambient_function
-            (identifier)
-            (call_signature
-              (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
-              (type_annotation (predefined_type)))))
-        (ambient_namespace_element
-          (lexical_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
-        (ambient_namespace_element
-          (interface_declaration
-            (identifier)
-            (object_type
-              (property_signature (identifier) (type_annotation (predefined_type))))))
-        (ambient_namespace_element
-          (interface_declaration
-            (identifier)
-            (object_type
-              (property_signature (identifier) (type_annotation (predefined_type)))
-              (property_signature (identifier) (type_annotation (predefined_type)))
-              (property_signature (identifier) (type_annotation (predefined_type)))))))))
+        (ambient_function
+          (identifier)
+          (call_signature
+            (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
+            (type_annotation (predefined_type))))
+        (lexical_declaration (variable_declarator (identifier) (type_annotation (predefined_type))))
+        (interface_declaration
+          (identifier)
+          (object_type
+            (property_signature (identifier) (type_annotation (predefined_type)))))
+        (interface_declaration
+          (identifier)
+          (object_type
+            (property_signature (identifier) (type_annotation (predefined_type)))
+            (property_signature (identifier) (type_annotation (predefined_type)))
+            (property_signature (identifier) (type_annotation (predefined_type))))))))
 
   (ambient_declaration
     (class
@@ -309,5 +305,10 @@ declare namespace moment {
     (ambient_namespace
       (identifier)
       (ambient_namespace_body
-      (ambient_namespace_element (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))) (ambient_namespace_element (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))) (ambient_namespace_element (ambient_export_declaration (class (identifier) (class_body)))) (ambient_namespace_element (ambient_export_declaration (ambient_function (identifier) (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))) (ambient_namespace_element (ambient_export_declaration (enum_declaration (identifier) (identifier) (identifier) (identifier))))))))
+        (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))
+        (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
+        (ambient_export_declaration (class (identifier) (class_body)))
+        (ambient_export_declaration
+          (ambient_function (identifier) (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))
+        (ambient_export_declaration (enum_declaration (identifier) (identifier) (identifier) (identifier)))))))
 

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -255,3 +255,33 @@ foo as any as Array<number>
     (type_assertion (type_arguments (predefined_type)) (identifier)))
   (expression_statement
     (as_expression (as_expression (identifier) (predefined_type)) (type_reference (identifier) (type_arguments (predefined_type))))))
+
+=================================
+Ambient export function declarations
+=================================
+
+export interface Foo {
+  export function OrderedMap<K, V>(iter: Iterable.Keyed<K, V>): OrderedMap<K, V>;
+}
+
+---
+
+(program
+  (export_statement
+    (interface_declaration
+      (identifier)
+      (object_type
+        (ambient_export_declaration
+          (ambient_function
+            (identifier)
+            (call_signature
+              (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
+              (formal_parameters
+                (required_parameter
+                  (identifier)
+                  (type_annotation
+                    (type_reference
+                      (identifier)
+                      (identifier)
+                      (type_arguments (type_reference (identifier)) (type_reference (identifier)))))))
+                      (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)) (type_reference (identifier))))))))))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -216,3 +216,12 @@ module Promise {
             (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))
         (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
 
+=================================
+Accessibility modifiers as pair keywords
+=================================
+
+{ name, description, private: private_ }
+
+---
+
+(program (expression_statement (object (identifier) (identifier) (pair (accessibility_modifier) (identifier)))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -169,3 +169,23 @@ export class CloningRepository {
         (accessibility_modifier)
         (readonly)
         (variable_declarator (identifier) (math_op (identifier))))))))
+
+==================================
+Ambient type declarations
+================================
+
+declare type IndexableType = string | number | Date | Array<string | number | Date>;
+
+---
+
+(program
+  (ambient_declaration
+    (type_alias_declaration
+      (identifier)
+        (union_type
+          (union_type
+            (union_type (predefined_type) (predefined_type))
+            (type_reference (identifier)))
+            (type_reference
+              (identifier)
+              (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_reference (identifier)))))))))

--- a/grammar_test/types.txt
+++ b/grammar_test/types.txt
@@ -241,6 +241,12 @@ interface G<T, U extends B> {
     y: U;
 }
 
+interface X {
+  hook: {
+  }
+  get(key: Key): Promise<T>;
+}
+
 ---
 
 (program
@@ -261,7 +267,18 @@ interface G<T, U extends B> {
     (type_parameters (type_parameter (identifier)) (type_parameter (identifier) (constraint (type_reference (identifier)))))
     (object_type
       (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier)))))))
+      (property_signature (identifier) (type_annotation (type_reference (identifier))))))
+  (interface_declaration
+    (identifier)
+    (object_type
+      (property_signature (identifier) (type_annotation (object_type)))
+      (method_signature
+        (identifier)
+        (call_signature
+          (formal_parameters
+            (required_parameter (identifier) (type_annotation (type_reference (identifier)))))
+          (type_annotation
+            (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
 
 =======================================
 Existential types
@@ -348,3 +365,46 @@ type HandlerFunction<T: Element> = void
     (identifier)
     (type_parameters (type_parameter (identifier) (constraint (type_reference (identifier)))))
   (predefined_type)))
+
+
+=======================================
+Nested type arguments
+=======================================
+
+interface X {
+  x(): Promise<Array<Foo>>;
+}
+
+---
+
+(program
+  (interface_declaration
+    (identifier)
+    (object_type
+      (method_signature
+        (identifier)
+        (call_signature
+          (formal_parameters)
+          (type_annotation
+            (type_reference
+              (identifier)
+              (type_arguments
+                (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))))
+
+=======================================
+predefined types as identifiers
+=======================================
+
+let score: (string: string, query: string) => number
+
+---
+
+(program
+  (lexical_declaration (variable_declarator
+    (identifier)
+    (type_annotation
+    (function_type
+      (formal_parameters
+        (required_parameter (parameter_identifier) (type_annotation (predefined_type)))
+        (required_parameter (identifier) (type_annotation (predefined_type))))
+      (predefined_type))))))

--- a/grammar_test/types.txt
+++ b/grammar_test/types.txt
@@ -372,7 +372,7 @@ Nested type arguments
 =======================================
 
 interface X {
-  x(): Promise<Array<Foo>>;
+  x(): Promise<Array<Foo> >;
 }
 
 ---

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5170,19 +5170,49 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "import_statement"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "import_statement"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "export_statement"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ambient_function"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_declaration"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "export_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_declaration"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_line_break"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -333,6 +333,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "module"
+          },
+          {
+            "type": "SYMBOL",
             "name": "variable_declaration"
           },
           {
@@ -4401,37 +4405,8 @@
       }
     },
     "identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "any"
-        },
-        {
-          "type": "STRING",
-          "value": "number"
-        },
-        {
-          "type": "STRING",
-          "value": "boolean"
-        },
-        {
-          "type": "STRING",
-          "value": "string"
-        },
-        {
-          "type": "STRING",
-          "value": "symbol"
-        },
-        {
-          "type": "STRING",
-          "value": "void"
-        },
-        {
-          "type": "PATTERN",
-          "value": "[\\a_$][\\a\\d_$]*"
-        }
-      ]
+      "type": "PATTERN",
+      "value": "[\\a_$][\\a\\d_$]*"
     },
     "this_expression": {
       "type": "STRING",
@@ -5010,6 +4985,10 @@
             },
             {
               "type": "SYMBOL",
+              "name": "module"
+            },
+            {
+              "type": "SYMBOL",
               "name": "type_alias_declaration"
             }
           ]
@@ -5157,6 +5136,56 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "module": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "module"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "import_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "export_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_declaration"
+              }
+            ]
+          }
         },
         {
           "type": "STRING",
@@ -5582,6 +5611,35 @@
         }
       ]
     },
+    "parameter_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "any"
+        },
+        {
+          "type": "STRING",
+          "value": "number"
+        },
+        {
+          "type": "STRING",
+          "value": "boolean"
+        },
+        {
+          "type": "STRING",
+          "value": "string"
+        },
+        {
+          "type": "STRING",
+          "value": "symbol"
+        },
+        {
+          "type": "STRING",
+          "value": "void"
+        }
+      ]
+    },
     "required_parameter": {
       "type": "CHOICE",
       "members": [
@@ -5604,54 +5662,21 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "assignment_pattern"
+                    }
+                  ]
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "assignment_pattern"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type_annotation"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "accessibility_modifier"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "assignment_pattern"
+                  "name": "parameter_identifier"
                 }
               ]
             },
@@ -5668,8 +5693,16 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "_initializer"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_initializer"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -6202,6 +6235,10 @@
                           {
                             "type": "STRING",
                             "value": ";"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_line_break"
                           }
                         ]
                       },
@@ -6873,6 +6910,10 @@
     [
       "_expression",
       "type_query"
+    ],
+    [
+      "parameter_identifier",
+      "predefined_type"
     ]
   ],
   "externals": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5314,18 +5314,6 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "export"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "SYMBOL",
               "name": "ambient_variable"
             },
@@ -5356,6 +5344,10 @@
             {
               "type": "SYMBOL",
               "name": "import_alias"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_alias_declaration"
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -923,7 +923,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "assignment_pattern"
+              "name": "destructuring_pattern"
             },
             {
               "type": "CHOICE",
@@ -2357,6 +2357,10 @@
             {
               "type": "SYMBOL",
               "name": "spread_element"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "assignment_pattern"
             }
           ]
         },
@@ -2388,6 +2392,19 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "assignment_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_initializer"
         }
       ]
     },
@@ -3013,7 +3030,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "assignment_pattern"
+                    "name": "destructuring_pattern"
                   }
                 ]
               }
@@ -3106,7 +3123,7 @@
         ]
       }
     },
-    "assignment_pattern": {
+    "destructuring_pattern": {
       "type": "CHOICE",
       "members": [
         {
@@ -4764,23 +4781,32 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "reserved_identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "string"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "number"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "reserved_identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "string"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "number"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "accessibility_modifier"
+                }
+              ]
             }
           ]
         },
@@ -5708,7 +5734,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "assignment_pattern"
+                      "name": "destructuring_pattern"
                     }
                   ]
                 },
@@ -5773,7 +5799,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "assignment_pattern"
+                  "name": "destructuring_pattern"
                 }
               ]
             },
@@ -5819,7 +5845,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "assignment_pattern"
+                  "name": "destructuring_pattern"
                 }
               ]
             },
@@ -6852,12 +6878,16 @@
       "_expression"
     ],
     [
-      "assignment_pattern",
+      "destructuring_pattern",
       "_expression"
     ],
     [
       "_expression",
       "_property_definition_list"
+    ],
+    [
+      "assignment_pattern",
+      "assignment"
     ],
     [
       "required_parameter",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2167,139 +2167,152 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "object"
+          "name": "type_assertion"
         },
         {
           "type": "SYMBOL",
-          "name": "array"
+          "name": "as_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "jsx_element"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "jsx_self_closing_element"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "class"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "function"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "arrow_function"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "generator_function"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "function_call"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "new_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "await_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "member_access"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "subscript_access"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "assignment"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "math_assignment"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ternary"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "bool_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "math_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "bitwise_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "rel_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "type_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "delete_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "void_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_paren_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "this_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "number"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "template_string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "regex"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "true"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "false"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "null"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "undefined"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "object"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "array"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "jsx_element"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "jsx_self_closing_element"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "class"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "arrow_function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "generator_function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_call"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "new_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "await_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "member_access"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "subscript_access"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "assignment"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "math_assignment"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "ternary"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "bool_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "math_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "bitwise_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "rel_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "delete_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "void_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_paren_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "this_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_string"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "regex"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "true"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "false"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "null"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "undefined"
+            }
+          ]
         }
       ]
     },
@@ -4953,6 +4966,44 @@
         }
       ]
     },
+    "type_assertion": {
+      "type": "PREC",
+      "value": 15,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "type_arguments"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "as_expression": {
+      "type": "PREC",
+      "value": 14,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "STRING",
+            "value": "as"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_type"
+          }
+        ]
+      }
+    },
     "implements_clause": {
       "type": "SEQ",
       "members": [
@@ -5131,29 +5182,8 @@
           "value": "namespace"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "entity_name"
         },
         {
           "type": "STRING",
@@ -5353,29 +5383,33 @@
       ]
     },
     "entity_name": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              }
-            ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "."
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "ambient_binding": {
       "type": "SEQ",
@@ -6026,29 +6060,8 @@
           "value": "typeof"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "entity_name"
         }
       ]
     },
@@ -6186,29 +6199,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "entity_name"
         },
         {
           "type": "CHOICE",
@@ -6724,21 +6716,25 @@
       ]
     },
     "array_type": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_primary_type"
-        },
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 13,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_primary_type"
+          },
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
     },
     "tuple_type": {
       "type": "SEQ",
@@ -6960,16 +6956,16 @@
     ],
     [
       "required_parameter",
-      "type_reference"
+      "entity_name"
     ],
     [
       "_expression",
       "required_parameter",
-      "type_reference"
+      "entity_name"
     ],
     [
       "_expression",
-      "type_reference"
+      "entity_name"
     ],
     [
       "ambient_binding",
@@ -6982,6 +6978,22 @@
     [
       "parameter_identifier",
       "predefined_type"
+    ],
+    [
+      "entity_name",
+      "type_parameter"
+    ],
+    [
+      "jsx_opening_element",
+      "entity_name"
+    ],
+    [
+      "jsx_opening_element",
+      "entity_name",
+      "type_parameter"
+    ],
+    [
+      "type_reference"
     ]
   ],
   "externals": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5183,7 +5183,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "entity_name"
+          "name": "_entity_name"
         },
         {
           "type": "STRING",
@@ -5365,7 +5365,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "entity_name"
+          "name": "_entity_name"
         },
         {
           "type": "CHOICE",
@@ -5382,7 +5382,7 @@
         }
       ]
     },
-    "entity_name": {
+    "_entity_name": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -6061,7 +6061,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "entity_name"
+          "name": "_entity_name"
         }
       ]
     },
@@ -6200,7 +6200,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "entity_name"
+          "name": "_entity_name"
         },
         {
           "type": "CHOICE",
@@ -6956,16 +6956,16 @@
     ],
     [
       "required_parameter",
-      "entity_name"
+      "_entity_name"
     ],
     [
       "_expression",
       "required_parameter",
-      "entity_name"
+      "_entity_name"
     ],
     [
       "_expression",
-      "entity_name"
+      "_entity_name"
     ],
     [
       "ambient_binding",
@@ -6980,16 +6980,16 @@
       "predefined_type"
     ],
     [
-      "entity_name",
+      "_entity_name",
       "type_parameter"
     ],
     [
       "jsx_opening_element",
-      "entity_name"
+      "_entity_name"
     ],
     [
       "jsx_opening_element",
-      "entity_name",
+      "_entity_name",
       "type_parameter"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4862,8 +4862,37 @@
           "value": "export"
         },
         {
-          "type": "SYMBOL",
-          "name": "ambient_function"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "ambient_variable"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "ambient_function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "class"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_ambient_enum"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "ambient_namespace"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "module"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_alias_declaration"
+            }
+          ]
         }
       ]
     },
@@ -5303,55 +5332,50 @@
     "ambient_namespace_body": {
       "type": "REPEAT1",
       "content": {
-        "type": "SYMBOL",
-        "name": "ambient_namespace_element"
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "ambient_export_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "ambient_variable"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "lexical_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "ambient_function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "class"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interface_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ambient_enum"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "ambient_namespace"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "import_alias"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "type_alias_declaration"
+          }
+        ]
       }
-    },
-    "ambient_namespace_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "ambient_variable"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "lexical_declaration"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ambient_function"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "class"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "interface_declaration"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_ambient_enum"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ambient_namespace"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "import_alias"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "type_alias_declaration"
-            }
-          ]
-        }
-      ]
     },
     "import_alias": {
       "type": "SEQ",
@@ -6025,6 +6049,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "type_predicate"
+        },
+        {
+          "type": "SYMBOL",
           "name": "object_type"
         },
         {
@@ -6054,6 +6082,23 @@
         {
           "type": "SYMBOL",
           "name": "literal_type"
+        }
+      ]
+    },
+    "type_predicate": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "is"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -170,8 +170,16 @@
               "value": "export"
             },
             {
-              "type": "STRING",
-              "value": "default"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "default"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4854,6 +4854,19 @@
       "type": "STRING",
       "value": "\n"
     },
+    "ambient_export_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "export"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ambient_function"
+        }
+      ]
+    },
     "ambient_method_declaration": {
       "type": "SEQ",
       "members": [
@@ -6340,6 +6353,10 @@
         "members": [
           {
             "type": "SYMBOL",
+            "name": "ambient_export_declaration"
+          },
+          {
+            "type": "SYMBOL",
             "name": "property_signature"
           },
           {
@@ -6994,6 +7011,10 @@
     ],
     [
       "type_reference"
+    ],
+    [
+      "export_statement",
+      "ambient_export_declaration"
     ]
   ],
   "externals": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5007,6 +5007,10 @@
             {
               "type": "SYMBOL",
               "name": "ambient_namespace"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_alias_declaration"
             }
           ]
         }


### PR DESCRIPTION
Adds support for:

- [x] Ambient type alias declarations
- [x] Type assertions and as expressions
- [x] Allow accessibility modifiers as pair keys in objects
- [x] Allow exporting ambient function declarations without the default keyword
- [x] Add ambient function declarations to modules