### PR TITLE
Do not hide `module` keyword

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -191,7 +191,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     type_op: ($, previous) => choice(
-      prec(PREC.TYPEOF, seq('typeof', choice($.anonymous_class, 'module'))),
+      prec(PREC.TYPEOF, seq('typeof', choice($.anonymous_class, $.reserved_identifier))),
       previous
     ),
 
@@ -412,7 +412,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     member_access: $ => prec(PREC.MEMBER, seq(
-      choice($._expression, 'module'),
+      choice($._expression, $.reserved_identifier),
       '.',
       $.identifier
     )),
@@ -510,7 +510,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       'string',
       'symbol',
       'void'
-      ),
+    ),
 
     required_parameter: $ => choice(
       seq(

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -27,8 +27,8 @@ typeof module === "object" && typeof module.exports === "object"
 
   (expression_statement
     (bool_op
-      (rel_op (type_op) (string))
-      (rel_op (type_op (member_access (identifier))) (string)))))
+      (rel_op (type_op (reserved_identifier)) (string))
+      (rel_op (type_op (member_access (reserved_identifier) (identifier))) (string)))))
 
 ==================================
 Array with empty elements

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2603,8 +2603,8 @@
                 "name": "_expression"
               },
               {
-                "type": "STRING",
-                "value": "module"
+                "type": "SYMBOL",
+                "name": "reserved_identifier"
               }
             ]
           },
@@ -3553,8 +3553,8 @@
                     "name": "anonymous_class"
                   },
                   {
-                    "type": "STRING",
-                    "value": "module"
+                    "type": "SYMBOL",
+                    "name": "reserved_identifier"
                   }
                 ]
               }


### PR DESCRIPTION
I noticed we were hiding the `module` keyword in `type_op` and `member_access` rules. This leverages our `reserved_identifier` rule to gain better flexibility for those reserved keywords when used in a type operator expression or member access expression.

/cc @maxbrunsfeld 