### PR TITLE
Update to use new aliasing features

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -67,9 +67,9 @@ declare module Foo {
       (class_body
         (public_field_definition (property_identifier) (type_annotation (type_reference (identifier)))))))
   (ambient_declaration
-    (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
+    (variable_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
   (ambient_declaration
-    (ambient_variable (ambient_binding (identifier)) (string)))
+    (lexical_declaration (variable_declarator (identifier) (string))))
   (ambient_declaration
     (ambient_function
       (identifier)
@@ -78,9 +78,9 @@ declare module Foo {
         (type_annotation (predefined_type)))))
 
   (ambient_declaration
-    (ambient_namespace
+    (internal_module
       (identifier)
-      (ambient_namespace_body
+      (statement_block
         (ambient_function
           (identifier)
           (call_signature
@@ -393,7 +393,7 @@ export interface Foo {
     (interface_declaration
       (identifier)
       (object_type
-        (ambient_export_declaration
+        (export_statement
           (ambient_function
             (identifier)
             (call_signature
@@ -428,15 +428,15 @@ declare namespace moment {
 
 (program
   (ambient_declaration
-    (ambient_namespace (identifier) (ambient_namespace_body
+    (internal_module (identifier) (statement_block
       (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))
-      (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
-      (ambient_export_declaration (class (identifier) (class_body)))
-      (ambient_export_declaration
+      (export_statement (variable_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
+      (export_statement (class (identifier) (class_body)))
+      (export_statement
         (ambient_function
           (identifier)
           (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))
-      (ambient_export_declaration (enum_declaration (identifier) (enum_body
+      (export_statement (enum_declaration (identifier) (enum_body
         (property_identifier)
         (property_identifier)
         (property_identifier))))))))
@@ -455,9 +455,9 @@ declare namespace Foo {
 
 (program
   (ambient_declaration
-    (ambient_namespace
+    (internal_module
       (identifier)
-      (ambient_namespace_body (ambient_export_declaration (interface_declaration (identifier) (object_type)))))))
+      (statement_block (export_statement (interface_declaration (identifier) (object_type)))))))
 
 =================================
 Namespaces as internal modules
@@ -543,7 +543,7 @@ declare global {
 
 ---
 
-(program (ambient_declaration (ambient_namespace_body)))
+(program (ambient_declaration (statement_block)))
 
 =======================================
 Abstract classes

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -65,7 +65,7 @@ declare module Foo {
     (class
       (identifier)
       (class_body
-        (public_field_definition (property_identifier) (type_annotation (type_reference (identifier)))))))
+        (public_field_definition (property_identifier) (type_annotation (type_identifier))))))
   (ambient_declaration
     (variable_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
   (ambient_declaration
@@ -108,7 +108,7 @@ declare module Foo {
         (method_definition (property_identifier) (call_signature (formal_parameters) (type_annotation (predefined_type)))))))
 
   (ambient_declaration
-    (module (identifier) (identifier) (statement_block
+    (module (nested_identifier (identifier) (identifier)) (statement_block
       (export_statement (variable_declaration (variable_declarator (identifier)))))))
 
   (empty_statement)
@@ -195,7 +195,7 @@ import r = X.N;
 
 (program
   (expression_statement
-    (import_alias (identifier) (identifier) (identifier))))
+    (import_alias (identifier) (nested_identifier (identifier) (identifier)))))
 
 ==================================
 Import aliases in modules
@@ -209,7 +209,8 @@ module C {
 
 (program
   (module (identifier) (statement_block
-    (expression_statement (import_alias (identifier) (identifier) (identifier))))))
+    (expression_statement
+      (import_alias (identifier) (nested_identifier (identifier) (identifier)))))))
 
 ==================================
 Export import aliases
@@ -252,7 +253,7 @@ export class CloningRepository {
           (accessibility_modifier)
           (readonly)
           (property_identifier)
-          (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))
+          (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier))))))))
   (export_statement
     (class
       (identifier)
@@ -277,10 +278,10 @@ declare type IndexableType = string | number | Date | Array<string | number | Da
         (union_type
           (union_type
             (union_type (predefined_type) (predefined_type))
-            (type_reference (identifier)))
-            (type_reference
-              (identifier)
-              (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_reference (identifier)))))))))
+            (type_identifier))
+            (generic_type
+              (type_identifier)
+              (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_identifier))))))))
 
 ==================================
 Ambient module declarations
@@ -309,8 +310,8 @@ declare module "example" { }
         (formal_parameters
           (optional_parameter
             (identifier)
-            (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))
-        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
+            (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier))))))
+        (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
 
   (ambient_declaration (module (string)))
   (ambient_declaration (module (string) (statement_block))))
@@ -376,7 +377,7 @@ foo as any as Array<number>
   (expression_statement
     (type_assertion (type_arguments (predefined_type)) (identifier)))
   (expression_statement
-    (as_expression (as_expression (identifier) (predefined_type)) (type_reference (identifier) (type_arguments (predefined_type))))))
+    (as_expression (as_expression (identifier) (predefined_type)) (generic_type (type_identifier) (type_arguments (predefined_type))))))
 
 =================================
 Ambient export function declarations
@@ -402,11 +403,10 @@ export interface Foo {
                 (required_parameter
                   (identifier)
                   (type_annotation
-                    (type_reference
-                      (identifier)
-                      (identifier)
-                      (type_arguments (type_reference (identifier)) (type_reference (identifier)))))))
-                      (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)) (type_reference (identifier))))))))))))
+                    (generic_type
+                      (nested_type_identifier (identifier) (type_identifier))
+                      (type_arguments (type_identifier) (type_identifier))))))
+                      (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier) (type_identifier)))))))))))
 
 
 =================================
@@ -435,7 +435,7 @@ declare namespace moment {
       (export_statement
         (ambient_function
           (identifier)
-          (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))
+          (call_signature (formal_parameters) (type_annotation (type_identifier)))))
       (export_statement (enum_declaration (identifier) (enum_body
         (property_identifier)
         (property_identifier)
@@ -503,7 +503,7 @@ class Foo {
           (call_signature (formal_parameters)))
         (method_definition
           (property_identifier)
-          (call_signature (formal_parameters) (type_annotation (type_reference (identifier)))))
+          (call_signature (formal_parameters) (type_annotation (type_identifier))))
         (method_definition
           (accessibility_modifier)
           (property_identifier)
@@ -530,9 +530,9 @@ class Foo {
     (class_body
       (public_field_definition (number) (type_annotation (predefined_type)))
       (public_field_definition (accessibility_modifier) (number) (type_annotation (predefined_type)) (string))
-      (public_field_definition (accessibility_modifier) (readonly) (string) (type_annotation (type_reference (identifier))) (string))
-      (public_field_definition (readonly) (string) (type_annotation (type_reference (identifier))) (string))
-      (public_field_definition (readonly) (string) (type_annotation (type_reference (identifier))) (string))))))
+      (public_field_definition (accessibility_modifier) (readonly) (string) (type_annotation (type_identifier)) (string))
+      (public_field_definition (readonly) (string) (type_annotation (type_identifier)) (string))
+      (public_field_definition (readonly) (string) (type_annotation (type_identifier)) (string))))))
 
 =======================================
 Global namespace declarations

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -65,7 +65,7 @@ declare module Foo {
     (class
       (identifier)
       (class_body
-        (public_field_definition (identifier) (type_annotation (type_reference (identifier)))))))
+        (public_field_definition (property_identifier) (type_annotation (type_reference (identifier)))))))
   (ambient_declaration
     (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
   (ambient_declaration
@@ -90,33 +90,31 @@ declare module Foo {
         (interface_declaration
           (identifier)
           (object_type
-            (property_signature (identifier) (type_annotation (predefined_type)))))
+            (property_signature (property_identifier) (type_annotation (predefined_type)))))
         (interface_declaration
           (identifier)
           (object_type
-            (property_signature (identifier) (type_annotation (predefined_type)))
-            (property_signature (identifier) (type_annotation (predefined_type)))
-            (property_signature (identifier) (type_annotation (predefined_type))))))))
+            (property_signature (property_identifier) (type_annotation (predefined_type)))
+            (property_signature (property_identifier) (type_annotation (predefined_type)))
+            (property_signature (property_identifier) (type_annotation (predefined_type))))))))
 
   (ambient_declaration
     (class
       (identifier)
       (class_body
         (method_definition
-          (identifier) (call_signature (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))))
-        (public_field_definition (identifier) (type_annotation (predefined_type)))
-        (method_definition (identifier) (call_signature (formal_parameters) (type_annotation (predefined_type)))))))
+          (property_identifier) (call_signature (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))))
+        (public_field_definition (property_identifier) (type_annotation (predefined_type)))
+        (method_definition (property_identifier) (call_signature (formal_parameters) (type_annotation (predefined_type)))))))
 
   (ambient_declaration
-    (module
-      (identifier)
-      (identifier)
-      (export_statement (variable_declaration (variable_declarator (identifier))))))
-      (empty_statement)
+    (module (identifier) (identifier) (statement_block
+      (export_statement (variable_declaration (variable_declarator (identifier)))))))
+
+  (empty_statement)
 
   (ambient_declaration
-    (module
-      (identifier)
+    (module (identifier) (statement_block
       (break_statement)
       (continue_statement)
       (debugger_statement)
@@ -132,7 +130,7 @@ declare module Foo {
         (statement_block)
         (catch (identifier) (statement_block))
         (finally (statement_block)))
-      (with_statement (identifier) (statement_block)))))
+      (with_statement (identifier) (statement_block))))))
 
 ==================================
 Ambient exports
@@ -155,7 +153,7 @@ export default class A {}
           (required_parameter (identifier) (type_annotation (predefined_type)))
           (required_parameter (identifier) (type_annotation (predefined_type)))))
           (statement_block
-            (return_statement (object (identifier) (identifier))))))
+            (return_statement (object (shorthand_property_identifier) (shorthand_property_identifier))))))
   (export_statement (class (identifier) (class_body))))
 
 ==================================
@@ -174,7 +172,7 @@ declare class Linter {
       (identifier)
       (class_body
         (public_field_definition
-          (identifier)
+          (property_identifier)
           (type_annotation (type_query (identifier))))))))
 
 ==================================
@@ -210,7 +208,8 @@ module C {
 ---
 
 (program
-  (module (identifier) (expression_statement (import_alias (identifier) (identifier) (identifier)))))
+  (module (identifier) (statement_block
+    (expression_statement (import_alias (identifier) (identifier) (identifier))))))
 
 ==================================
 Export import aliases
@@ -225,9 +224,9 @@ module M {
 ---
 
 (program
-  (module (identifier)
-    (export_statement (module (identifier)))
-    (export_statement (import_alias (identifier) (identifier)))))
+  (module (identifier) (statement_block
+    (export_statement (module (identifier) (statement_block)))
+    (export_statement (import_alias (identifier) (identifier))))))
 
 ==================================
 Property signatures with accessibility modifiers
@@ -252,7 +251,7 @@ export class CloningRepository {
         (property_signature
           (accessibility_modifier)
           (readonly)
-          (identifier)
+          (property_identifier)
           (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))
   (export_statement
     (class
@@ -261,7 +260,7 @@ export class CloningRepository {
         (public_field_definition
         (accessibility_modifier)
         (readonly)
-        (identifier) (math_op (identifier)))))))
+        (property_identifier) (math_op (identifier)))))))
 
 ==================================
 Ambient type declarations
@@ -299,8 +298,7 @@ declare module "example" { }
 ---
 
 (program
-  (module
-    (identifier)
+  (module (identifier) (statement_block
     (variable_declaration (variable_declarator
       (identifier)
       (type_annotation (object_type))))
@@ -312,10 +310,10 @@ declare module "example" { }
           (optional_parameter
             (identifier)
             (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))
-        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))
+        (type_annotation (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
 
   (ambient_declaration (module (string)))
-  (ambient_declaration (module (string))))
+  (ambient_declaration (module (string) (statement_block))))
 
 =================================
 Accessibility modifiers as pair keywords
@@ -325,7 +323,10 @@ Accessibility modifiers as pair keywords
 
 ---
 
-(program (expression_statement (object (identifier) (identifier) (pair (accessibility_modifier) (identifier)))))
+(program (expression_statement (object
+  (shorthand_property_identifier)
+  (shorthand_property_identifier)
+  (pair (property_identifier) (identifier)))))
 
 =================================
 JSX and type assertions
@@ -339,7 +340,27 @@ b = <div>{ <string>a } <span>b</span> c</div>;
 ---
 
 (program
-  (expression_statement (type_assertion (type_arguments (predefined_type)) (identifier))) (expression_statement (assignment (identifier) (jsx_self_closing_element (identifier) (jsx_attribute (identifier) (string)) (jsx_attribute (identifier) (number))))) (expression_statement (assignment (identifier) (jsx_element (jsx_opening_element (identifier)) (jsx_expression (type_assertion (type_arguments (predefined_type)) (identifier))) (jsx_text) (jsx_element (jsx_opening_element (identifier)) (jsx_text) (jsx_closing_element (identifier))) (jsx_text) (jsx_closing_element (identifier))))))
+  (expression_statement (type_assertion
+    (type_arguments (predefined_type))
+    (identifier)))
+  (expression_statement (assignment
+    (identifier)
+    (jsx_self_closing_element
+      (identifier)
+      (jsx_attribute (property_identifier) (string))
+      (jsx_attribute (property_identifier) (number)))))
+  (expression_statement (assignment
+    (identifier)
+    (jsx_element
+      (jsx_opening_element (identifier))
+      (jsx_expression (type_assertion (type_arguments (predefined_type)) (identifier)))
+      (jsx_text)
+      (jsx_element
+        (jsx_opening_element (identifier))
+        (jsx_text)
+        (jsx_closing_element (identifier)))
+      (jsx_text)
+      (jsx_closing_element (identifier))))))
 
 =================================
 Type assertions
@@ -407,15 +428,18 @@ declare namespace moment {
 
 (program
   (ambient_declaration
-    (ambient_namespace
-      (identifier)
-      (ambient_namespace_body
-        (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))
-        (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
-        (ambient_export_declaration (class (identifier) (class_body)))
-        (ambient_export_declaration
-          (ambient_function (identifier) (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))
-        (ambient_export_declaration (enum_declaration (identifier) (identifier) (identifier) (identifier)))))))
+    (ambient_namespace (identifier) (ambient_namespace_body
+      (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))
+      (ambient_export_declaration (ambient_variable (ambient_binding (identifier) (type_annotation (predefined_type)))))
+      (ambient_export_declaration (class (identifier) (class_body)))
+      (ambient_export_declaration
+        (ambient_function
+          (identifier)
+          (call_signature (formal_parameters) (type_annotation (type_reference (identifier))))))
+      (ambient_export_declaration (enum_declaration (identifier) (enum_body
+        (property_identifier)
+        (property_identifier)
+        (property_identifier))))))))
 
 
 =================================
@@ -450,15 +474,15 @@ namespace Bar {
 
 (program
   (expression_statement
-    (internal_module (identifier)))
+    (internal_module (identifier) (statement_block)))
 
   (expression_statement
-    (internal_module (identifier)
-    (variable_declaration (variable_declarator (identifier))))))
+    (internal_module (identifier) (statement_block
+    (variable_declaration (variable_declarator (identifier)))))))
 
-=======================================
-Method signatures with reserved identifiers
-=======================================
+===========================================
+Method declarations with keywords as names
+===========================================
 
 class Foo {
   private async();
@@ -475,14 +499,14 @@ class Foo {
       (class_body
         (method_definition
           (accessibility_modifier)
-          (reserved_identifier)
+          (property_identifier)
           (call_signature (formal_parameters)))
         (method_definition
-          (reserved_identifier)
+          (property_identifier)
           (call_signature (formal_parameters) (type_annotation (type_reference (identifier)))))
         (method_definition
           (accessibility_modifier)
-          (reserved_identifier)
+          (property_identifier)
           (call_signature (formal_parameters (required_parameter (identifier)))))))))
 
 =======================================
@@ -515,13 +539,11 @@ Global namespace declarations
 =======================================
 
 declare global {
-
 }
 
 ---
 
-(program (ambient_declaration))
-
+(program (ambient_declaration (ambient_namespace_body)))
 
 =======================================
 Abstract classes
@@ -547,16 +569,18 @@ abstract class Animal {
     (abstract_class (identifier) (class_body)))
   (expression_statement
     (abstract_class (identifier) (class_body
-      (public_field_definition (identifier) (type_annotation (predefined_type)))
-      (public_field_definition (identifier) (type_annotation (predefined_type)))
+      (public_field_definition (property_identifier) (type_annotation (predefined_type)))
+      (public_field_definition (property_identifier) (type_annotation (predefined_type)))
       (abstract_method_definition
-        (identifier)
+        (property_identifier)
         (call_signature (formal_parameters) (type_annotation (predefined_type))))
       (abstract_method_definition
-        (identifier)
+        (property_identifier)
         (call_signature (formal_parameters) (type_annotation (predefined_type))))
       (method_definition
-        (identifier)
+        (property_identifier)
         (call_signature (formal_parameters) (type_annotation (predefined_type)))
         (statement_block
-          (expression_statement (function_call (member_access (identifier) (identifier)) (arguments (string))))))))))
+          (expression_statement (function_call
+            (member_access (identifier) (property_identifier))
+            (arguments (string))))))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -7,7 +7,7 @@ as `hello`
 ---
 
 (program
-  (expression_statement (as_expression (template_string (template_chars)))))
+  (expression_statement (as_expression (template_string))))
 
 ==================================
 Typeof expressions
@@ -27,8 +27,8 @@ typeof module === "object" && typeof module.exports === "object"
 
   (expression_statement
     (bool_op
-      (rel_op (type_op (reserved_identifier)) (string))
-      (rel_op (type_op (member_access (reserved_identifier) (identifier))) (string)))))
+      (rel_op (type_op (identifier)) (string))
+      (rel_op (type_op (member_access (identifier) (property_identifier))) (string)))))
 
 ==================================
 Array with empty elements
@@ -56,7 +56,7 @@ Array with empty elements
 
 
 ==================================
-Module as reserved identifier
+Variable named 'module'
 ==================================
 
 var module;
@@ -65,8 +65,8 @@ module;
 ---
 
 (program
-  (variable_declaration (variable_declarator (reserved_identifier)))
-  (expression_statement (reserved_identifier)))
+  (variable_declaration (variable_declarator (identifier)))
+  (expression_statement (identifier)))
 
 ==================================
 Multi-line variable declarations

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -2,12 +2,12 @@
 As expressions
 ==================================
 
-as `hello`
+h as `hello`
 
 ---
 
 (program
-  (expression_statement (as_expression (template_string))))
+  (expression_statement (as_expression (identifier) (template_string))))
 
 ==================================
 Typeof expressions

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -92,7 +92,7 @@ const x = async => async;
 ---
 
 (program
-  (lexical_declaration (variable_declarator (identifier) (arrow_function (reserved_identifier) (reserved_identifier)))))
+  (lexical_declaration (variable_declarator (identifier) (arrow_function (identifier) (identifier)))))
 
 ==================================
 Super
@@ -116,7 +116,7 @@ class A extends B {
       (class_heritage (extends_clause (type_reference (identifier))))
       (class_body
         (method_definition
-          (identifier)
+          (property_identifier)
           (call_signature
             (formal_parameters
               (required_parameter (identifier) (type_annotation (predefined_type)))
@@ -125,10 +125,10 @@ class A extends B {
             (expression_statement (function_call (super) (arguments (identifier))))))
         (method_definition
           (accessibility_modifier)
-          (identifier)
+          (property_identifier)
           (call_signature (formal_parameters))
           (statement_block
             (return_statement
               (math_op
-                (math_op (function_call (member_access (super) (identifier)) (arguments)) (string))
-                (member_access (this_expression) (identifier))))))))))
+                (math_op (function_call (member_access (super) (property_identifier)) (arguments)) (string))
+                (member_access (this_expression) (property_identifier))))))))))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -28,8 +28,8 @@ function foo<T, U>(a: T[], f: (x: T) => U): U[] {
       (identifier)
       (call_signature
         (type_parameters (type_parameter (identifier)))
-        (formal_parameters (required_parameter (identifier) (type_annotation (type_reference (identifier)))))
-        (type_annotation (type_reference (identifier))))
+        (formal_parameters (required_parameter (identifier) (type_annotation (type_identifier))))
+        (type_annotation (type_identifier)))
         (statement_block)))
   (expression_statement
     (function
@@ -37,13 +37,13 @@ function foo<T, U>(a: T[], f: (x: T) => U): U[] {
       (call_signature
         (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
         (formal_parameters
-          (required_parameter (identifier) (type_annotation (array_type (type_reference (identifier)))))
+          (required_parameter (identifier) (type_annotation (array_type (type_identifier))))
           (required_parameter
             (identifier)
             (type_annotation
               (function_type
-                (formal_parameters (required_parameter (identifier) (type_annotation (type_reference (identifier))))) (type_reference (identifier))))))
-        (type_annotation (array_type (type_reference (identifier)))))
+                (formal_parameters (required_parameter (identifier) (type_annotation (type_identifier)))) (type_identifier)))))
+        (type_annotation (array_type (type_identifier))))
       (statement_block))))
 
 ==================================
@@ -58,7 +58,7 @@ const lines = new Array<DiffLine>()
   (lexical_declaration
     (variable_declarator
       (identifier)
-      (function_call (new_expression (identifier)) (type_arguments (type_reference (identifier))) (arguments)))))
+      (function_call (new_expression (identifier)) (type_arguments (type_identifier)) (arguments)))))
 
 ==================================
 Arrow functions and generators with call signatures
@@ -113,7 +113,7 @@ class A extends B {
   (expression_statement
     (class
       (identifier)
-      (class_heritage (extends_clause (type_reference (identifier))))
+      (class_heritage (extends_clause (type_identifier)))
       (class_body
         (method_definition
           (property_identifier)

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -41,8 +41,8 @@ let person: {name: string, age: number};
   (lexical_declaration (variable_declarator
     (identifier)
     (type_annotation (object_type
-      (property_signature (identifier) (type_annotation (predefined_type)))
-      (property_signature (identifier) (type_annotation (predefined_type))))))))
+      (property_signature (property_identifier) (type_annotation (predefined_type)))
+      (property_signature (property_identifier) (type_annotation (predefined_type))))))))
 
 =======================================
 Array types
@@ -106,8 +106,8 @@ const range = (document: any).selection.createRange()
     (identifier)
   (function_call
   (member_access
-    (member_access (identifier) (type_annotation (predefined_type)) (identifier))
-    (identifier))
+    (member_access (identifier) (type_annotation (predefined_type)) (property_identifier))
+    (property_identifier))
   (arguments)))))
 
 =======================================
@@ -167,17 +167,17 @@ type ConflictInfo = {
   (type_alias_declaration
     (identifier)
     (object_type
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (array_type (type_reference (identifier)))))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (array_type (type_reference (identifier)))))))
 
   (type_alias_declaration
     (identifier)
     (object_type
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier)))))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier)))))))
 
 =======================================
 Enum declarations
@@ -185,8 +185,8 @@ Enum declarations
 
 enum Test {
     A,
-    B,
-    C = Math.floor(Math.random() * 1000),
+    'B',
+    'C' = Math.floor(Math.random() * 1000),
     D = 10,
     E
 }
@@ -203,25 +203,23 @@ enum Style {
 ---
 
 (program
-  (enum_declaration
-    (identifier)
-    (identifier)
-    (identifier)
+  (enum_declaration (identifier) (enum_body
+    (property_identifier)
+    (string)
     (enum_assignment
-      (identifier)
+      (string)
       (function_call
-        (member_access (identifier) (identifier))
-        (arguments (math_op (function_call (member_access (identifier) (identifier)) (arguments)) (number)))))
-    (enum_assignment (identifier) (number))
-    (identifier))
-  (enum_declaration
-    (identifier)
-    (enum_assignment (identifier) (number))
-    (enum_assignment (identifier) (number))
-    (enum_assignment (identifier) (number))
-    (enum_assignment (identifier) (number))
-    (enum_assignment (identifier) (bitwise_op (identifier) (identifier)))
-    (enum_assignment (identifier) (bitwise_op (identifier) (identifier)))))
+        (member_access (identifier) (property_identifier))
+        (arguments (math_op (function_call (member_access (identifier) (property_identifier)) (arguments)) (number)))))
+    (enum_assignment (property_identifier) (number))
+    (property_identifier)))
+  (enum_declaration (identifier) (enum_body
+    (enum_assignment (property_identifier) (number))
+    (enum_assignment (property_identifier) (number))
+    (enum_assignment (property_identifier) (number))
+    (enum_assignment (property_identifier) (number))
+    (enum_assignment (property_identifier) (bitwise_op (identifier) (identifier)))
+    (enum_assignment (property_identifier) (bitwise_op (identifier) (identifier))))))
 
 =======================================
 Interface declarations
@@ -252,28 +250,28 @@ interface X {
 (program
   (interface_declaration
     (identifier)
-    (object_type (property_signature (identifier) (type_annotation (predefined_type)))))
+    (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
     (extends_clause (type_reference (identifier)))
-    (object_type (property_signature (identifier) (type_annotation (predefined_type)))))
+    (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
     (object_type
-      (property_signature (identifier) (type_annotation (predefined_type)))
-      (property_signature (identifier) (type_annotation (predefined_type)))))
+      (property_signature (property_identifier) (type_annotation (predefined_type)))
+      (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
     (type_parameters (type_parameter (identifier)) (type_parameter (identifier) (constraint (type_reference (identifier)))))
     (object_type
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (identifier) (type_annotation (type_reference (identifier))))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
+      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))))
   (interface_declaration
     (identifier)
     (object_type
-      (property_signature (identifier) (type_annotation (object_type)))
+      (property_signature (property_identifier) (type_annotation (object_type)))
       (method_signature
-        (reserved_identifier)
+        (property_identifier)
         (call_signature
           (formal_parameters
             (required_parameter (identifier) (type_annotation (type_reference (identifier)))))
@@ -329,8 +327,8 @@ type BrowserStats = {|
   (type_alias_declaration
     (identifier)
     (object_type
-      (property_signature (identifier) (type_annotation (predefined_type)))
-      (property_signature (identifier) (type_annotation (predefined_type))))))
+      (property_signature (property_identifier) (type_annotation (predefined_type)))
+      (property_signature (property_identifier) (type_annotation (predefined_type))))))
 
 
 =======================================
@@ -372,8 +370,10 @@ Nested type arguments
 =======================================
 
 interface X {
-  x(): Promise<Array<Foo> >;
+  x(): Promise<Array<Foo>>;
 }
+
+var y: Map<number, Promise<Map<bool, Map<Foo, Bar>>>>
 
 ---
 
@@ -382,14 +382,31 @@ interface X {
     (identifier)
     (object_type
       (method_signature
-        (identifier)
+        (property_identifier)
         (call_signature
           (formal_parameters)
           (type_annotation
             (type_reference
               (identifier)
               (type_arguments
-                (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))))
+                (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))))
+  (variable_declaration (variable_declarator
+    (identifier)
+    (type_annotation (type_reference
+      (identifier)
+      (type_arguments
+        (predefined_type)
+        (type_reference
+          (identifier)
+          (type_arguments (type_reference
+            (identifier)
+            (type_arguments
+              (type_reference (identifier))
+              (type_reference
+                (identifier)
+                (type_arguments
+                  (type_reference (identifier))
+                  (type_reference (identifier))))))))))))))
 
 =======================================
 predefined types as identifiers

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -55,7 +55,7 @@ let x: X[];
 (program
   (lexical_declaration (variable_declarator
     (identifier)
-    (type_annotation (array_type (type_reference (identifier)))))))
+    (type_annotation (array_type (type_identifier))))))
 
 =======================================
 Function types
@@ -90,7 +90,7 @@ let x: new < T1, T2 > ( p1, p2 ) => R;
         (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
         (formal_parameters
           (required_parameter (identifier)) (required_parameter (identifier)))
-        (type_reference (identifier)))))))
+        (type_identifier))))))
 
 
 =======================================
@@ -122,10 +122,10 @@ const miscArray: ?T[]
 (program
   (lexical_declaration (variable_declarator
     (identifier)
-    (type_annotation (flow_maybe_type (type_reference (identifier))))))
+    (type_annotation (flow_maybe_type (type_identifier)))))
   (lexical_declaration (variable_declarator
     (identifier)
-    (type_annotation (flow_maybe_type (array_type (type_reference (identifier))))))))
+    (type_annotation (flow_maybe_type (array_type (type_identifier)))))))
 
 =======================================
 Flow Import Types
@@ -167,17 +167,17 @@ type ConflictInfo = {
   (type_alias_declaration
     (identifier)
     (object_type
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (array_type (type_reference (identifier)))))))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (array_type (type_identifier))))))
 
   (type_alias_declaration
     (identifier)
     (object_type
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier)))))))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (type_identifier))))))
 
 =======================================
 Enum declarations
@@ -253,7 +253,7 @@ interface X {
     (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
-    (extends_clause (type_reference (identifier)))
+    (extends_clause (type_identifier))
     (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
@@ -262,10 +262,10 @@ interface X {
       (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
     (identifier)
-    (type_parameters (type_parameter (identifier)) (type_parameter (identifier) (constraint (type_reference (identifier)))))
+    (type_parameters (type_parameter (identifier)) (type_parameter (identifier) (constraint (type_identifier))))
     (object_type
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))
-      (property_signature (property_identifier) (type_annotation (type_reference (identifier))))))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))
+      (property_signature (property_identifier) (type_annotation (type_identifier)))))
   (interface_declaration
     (identifier)
     (object_type
@@ -274,9 +274,9 @@ interface X {
         (property_identifier)
         (call_signature
           (formal_parameters
-            (required_parameter (identifier) (type_annotation (type_reference (identifier)))))
+            (required_parameter (identifier) (type_annotation (type_identifier))))
           (type_annotation
-            (type_reference (identifier) (type_arguments (type_reference (identifier))))))))))
+            (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
 
 =======================================
 Existential types
@@ -289,7 +289,7 @@ let x: Array<*>
 (program
   (lexical_declaration (variable_declarator
     (identifier)
-    (type_annotation (type_reference (identifier) (type_arguments (existential_type)))))))
+    (type_annotation (generic_type (type_identifier) (type_arguments (existential_type)))))))
 
 =======================================
 Flow Union types
@@ -361,7 +361,7 @@ type HandlerFunction<T: Element> = void
 (program
   (type_alias_declaration
     (identifier)
-    (type_parameters (type_parameter (identifier) (constraint (type_reference (identifier)))))
+    (type_parameters (type_parameter (identifier) (constraint (type_identifier))))
   (predefined_type)))
 
 
@@ -386,27 +386,27 @@ var y: Map<number, Promise<Map<bool, Map<Foo, Bar>>>>
         (call_signature
           (formal_parameters)
           (type_annotation
-            (type_reference
-              (identifier)
+            (generic_type
+              (type_identifier)
               (type_arguments
-                (type_reference (identifier) (type_arguments (type_reference (identifier)))))))))))
+                (generic_type (type_identifier) (type_arguments (type_identifier))))))))))
   (variable_declaration (variable_declarator
     (identifier)
-    (type_annotation (type_reference
-      (identifier)
+    (type_annotation (generic_type
+      (type_identifier)
       (type_arguments
         (predefined_type)
-        (type_reference
-          (identifier)
-          (type_arguments (type_reference
-            (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments (generic_type
+            (type_identifier)
             (type_arguments
-              (type_reference (identifier))
-              (type_reference
-                (identifier)
+              (type_identifier)
+              (generic_type
+                (type_identifier)
                 (type_arguments
-                  (type_reference (identifier))
-                  (type_reference (identifier))))))))))))))
+                  (type_identifier)
+                  (type_identifier)))))))))))))
 
 =======================================
 predefined types as identifiers
@@ -422,7 +422,7 @@ let score: (string: string, query: string) => number
     (type_annotation
     (function_type
       (formal_parameters
-        (required_parameter (parameter_identifier) (type_annotation (predefined_type)))
+        (required_parameter (identifier) (type_annotation (predefined_type)))
         (required_parameter (identifier) (type_annotation (predefined_type))))
       (predefined_type))))))
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,9 @@
-module.exports = require("./build/Release/tree_sitter_typescript_binding");
+try {
+  module.exports = require("./build/Release/tree_sitter_typescript_binding");
+} catch (error) {
+  try {
+    module.exports = require("./build/Debug/tree_sitter_typescript_binding");
+  } catch (_) {
+    throw error
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-typescript",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Typescript grammar for tree-sitter",
   "main": "index.js",
   "keywords": [
@@ -13,7 +13,7 @@
     "nan": "^2.4.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.5.4",
+    "tree-sitter-cli": "^0.6.6-0",
     "tree-sitter-javascript": "tree-sitter/tree-sitter-javascript"
   },
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -250,8 +250,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "export_specifier"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_import_export_specifier"
+                  },
+                  "named": true,
+                  "value": "export_specifier"
                 },
                 {
                   "type": "REPEAT",
@@ -263,8 +268,13 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "export_specifier"
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_import_export_specifier"
+                        },
+                        "named": true,
+                        "value": "export_specifier"
                       }
                     ]
                   }
@@ -282,27 +292,31 @@
         }
       ]
     },
-    "export_specifier": {
-      "type": "CHOICE",
+    "_import_export_specifier": {
+      "type": "SEQ",
       "members": [
         {
           "type": "SYMBOL",
           "name": "identifier"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "as"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
             },
             {
-              "type": "STRING",
-              "value": "as"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "BLANK"
             }
           ]
         }
@@ -449,35 +463,36 @@
               "name": "identifier"
             },
             {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
-              "name": "namespace_import"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "namespace_import"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "named_imports"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
-              "name": "named_imports"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
         }
       ]
     },
@@ -525,8 +540,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "import_specifier"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_import_export_specifier"
+                  },
+                  "named": true,
+                  "value": "import_specifier"
                 },
                 {
                   "type": "REPEAT",
@@ -538,8 +558,13 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "import_specifier"
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_import_export_specifier"
+                        },
+                        "named": true,
+                        "value": "import_specifier"
                       }
                     ]
                   }
@@ -566,32 +591,6 @@
         {
           "type": "STRING",
           "value": "}"
-        }
-      ]
-    },
-    "import_specifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "STRING",
-              "value": "as"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
-          ]
         }
       ]
     },
@@ -701,17 +700,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -748,17 +738,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -804,17 +785,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -825,17 +797,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "reserved_identifier"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "CHOICE",
@@ -868,7 +831,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "destructuring_pattern"
+              "name": "_destructuring_pattern"
             },
             {
               "type": "CHOICE",
@@ -1260,17 +1223,8 @@
           "name": "_paren_expression"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1330,7 +1284,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_expression"
                 },
                 {
                   "type": "STRING",
@@ -1348,17 +1302,8 @@
           "name": "statement_block"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1373,8 +1318,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "named": true,
+              "value": "statement_identifier"
             },
             {
               "type": "BLANK"
@@ -1382,17 +1332,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1407,8 +1348,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "named": true,
+              "value": "statement_identifier"
             },
             {
               "type": "BLANK"
@@ -1416,17 +1362,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1438,17 +1375,8 @@
           "value": "debugger"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1481,17 +1409,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1516,17 +1435,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1538,8 +1448,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "named": true,
+          "value": "statement_identifier"
         },
         {
           "type": "STRING",
@@ -1825,10 +1740,6 @@
             },
             {
               "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
               "name": "number"
             },
             {
@@ -1865,32 +1776,45 @@
             },
             {
               "type": "SYMBOL",
-              "name": "reserved_identifier"
+              "name": "identifier"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_reserved_identifier"
+              },
+              "named": true,
+              "value": "identifier"
             }
           ]
         }
       ]
     },
     "yield_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "yield"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "yield"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "object": {
       "type": "PREC",
@@ -1936,12 +1860,22 @@
               "name": "method_definition"
             },
             {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "reserved_identifier"
+              "type": "ALIAS",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_reserved_identifier"
+                  }
+                ]
+              },
+              "named": true,
+              "value": "shorthand_property_identifier"
             },
             {
               "type": "SYMBOL",
@@ -1988,8 +1922,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "named": true,
+          "value": "shorthand_property_identifier"
         },
         {
           "type": "SYMBOL",
@@ -2170,8 +2109,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "named": true,
+          "value": "property_identifier"
         },
         {
           "type": "CHOICE",
@@ -2394,8 +2338,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "reserved_identifier"
+              "type": "STRING",
+              "value": "async"
             },
             {
               "type": "BLANK"
@@ -2443,16 +2387,13 @@
               "name": "call_signature"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "reserved_identifier"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_reserved_identifier"
+              },
+              "named": true,
+              "value": "identifier"
             }
           ]
         },
@@ -2596,25 +2537,21 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "reserved_identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_expression"
           },
           {
             "type": "STRING",
             "value": "."
           },
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            "named": true,
+            "value": "property_identifier"
           }
         ]
       }
@@ -2662,17 +2599,12 @@
                 "name": "subscript_access"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "destructuring_pattern"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_destructuring_pattern"
               }
             ]
           },
@@ -2772,16 +2704,26 @@
         ]
       }
     },
-    "destructuring_pattern": {
+    "_destructuring_pattern": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "object"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "object"
+          },
+          "named": true,
+          "value": "object_pattern"
         },
         {
-          "type": "SYMBOL",
-          "name": "array"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "array"
+          },
+          "named": true,
+          "value": "array_pattern"
         }
       ]
     },
@@ -3388,12 +3330,12 @@
       }
     },
     "rel_op": {
-      "type": "PREC_LEFT",
-      "value": 5,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3409,8 +3351,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3426,8 +3372,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3443,8 +3393,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3460,8 +3414,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3477,8 +3435,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3494,8 +3456,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3511,8 +3477,12 @@
                 "name": "_expression"
               }
             ]
-          },
-          {
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
             "type": "SEQ",
             "members": [
               {
@@ -3529,8 +3499,8 @@
               }
             ]
           }
-        ]
-      }
+        }
+      ]
     },
     "type_op": {
       "type": "CHOICE",
@@ -3546,17 +3516,8 @@
                 "value": "typeof"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "anonymous_class"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "reserved_identifier"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "anonymous_class"
               }
             ]
           }
@@ -3745,7 +3706,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "template_chars"
+                "name": "_template_chars"
               },
               {
                 "type": "SYMBOL",
@@ -3760,17 +3721,26 @@
         }
       ]
     },
-    "template_chars": {
+    "_template_chars": {
       "type": "TOKEN",
       "content": {
-        "type": "PREC_RIGHT",
-        "value": 0,
+        "type": "REPEAT1",
         "content": {
-          "type": "REPEAT1",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^`\\$]|\\$[^{]|\\\\`"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^`\\$]"
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\$[^{]"
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\\\`"
+            }
+          ]
         }
       }
     },
@@ -4595,8 +4565,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "reserved_identifier"
+                "type": "STRING",
+                "value": "async"
               },
               {
                 "type": "BLANK"
@@ -4655,17 +4625,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_property_name"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "accessibility_modifier"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_property_name"
         },
         {
           "type": "STRING",
@@ -4681,12 +4642,22 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "reserved_identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_reserved_identifier"
+              }
+            ]
+          },
+          "named": true,
+          "value": "property_identifier"
         },
         {
           "type": "SYMBOL",
@@ -4698,7 +4669,7 @@
         }
       ]
     },
-    "reserved_identifier": {
+    "_reserved_identifier": {
       "type": "CHOICE",
       "members": [
         {
@@ -4743,16 +4714,21 @@
             {
               "type": "STRING",
               "value": "async"
-            },
-            {
-              "type": "STRING",
-              "value": "abstract"
-            },
-            {
-              "type": "STRING",
-              "value": "interface"
             }
           ]
+        }
+      ]
+    },
+    "_semicolon": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_automatic_semicolon"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -5122,24 +5098,8 @@
                   "value": "global"
                 },
                 {
-                  "type": "STRING",
-                  "value": "{"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "ambient_namespace_body"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": "}"
+                  "type": "SYMBOL",
+                  "name": "ambient_namespace_body"
                 }
               ]
             }
@@ -5289,24 +5249,8 @@
           "name": "_entity_name"
         },
         {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "ambient_namespace_body"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "ambient_namespace_body"
         }
       ]
     },
@@ -5364,7 +5308,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_module_body"
+                "name": "statement_block"
               },
               {
                 "type": "BLANK"
@@ -5374,7 +5318,7 @@
         ]
       }
     },
-    "_module_body": {
+    "ambient_namespace_body": {
       "type": "SEQ",
       "members": [
         {
@@ -5384,8 +5328,58 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "ambient_export_declaration"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "interface_declaration"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ambient_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ambient_function"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "class"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_ambient_enum"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ambient_namespace"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "module"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_alias_declaration"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "lexical_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "import_alias"
+              }
+            ]
           }
         },
         {
@@ -5393,63 +5387,6 @@
           "value": "}"
         }
       ]
-    },
-    "ambient_namespace_body": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "ambient_export_declaration"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interface_declaration"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "ambient_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "ambient_function"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "class"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_ambient_enum"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "ambient_namespace"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "module"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "type_alias_declaration"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "lexical_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "import_alias"
-          }
-        ]
-      }
     },
     "import_alias": {
       "type": "SEQ",
@@ -5634,6 +5571,15 @@
           "name": "identifier"
         },
         {
+          "type": "SYMBOL",
+          "name": "enum_body"
+        }
+      ]
+    },
+    "enum_body": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "{"
         },
@@ -5641,8 +5587,46 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_enum_body"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_enum_member"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_enum_member"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -5655,59 +5639,12 @@
         }
       ]
     },
-    "_enum_body": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_enum_member"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_enum_member"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
     "_enum_member": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_property_name"
         },
         {
           "type": "SYMBOL",
@@ -5720,7 +5657,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_property_name"
         },
         {
           "type": "SYMBOL",
@@ -5875,7 +5812,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "destructuring_pattern"
+                      "name": "_destructuring_pattern"
                     }
                   ]
                 },
@@ -5940,7 +5877,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "destructuring_pattern"
+                  "name": "_destructuring_pattern"
                 }
               ]
             },
@@ -5986,7 +5923,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "destructuring_pattern"
+                  "name": "_destructuring_pattern"
                 }
               ]
             },
@@ -7024,35 +6961,33 @@
       "_property_name"
     ],
     [
-      "labeled_statement",
-      "_property_name"
-    ],
-    [
-      "reserved_identifier",
+      "_expression",
+      "_property_name",
       "arrow_function"
     ],
     [
-      "formal_parameters",
-      "_expression"
+      "_expression",
+      "arrow_function"
     ],
     [
-      "destructuring_pattern",
-      "_expression"
+      "_expression",
+      "method_definition"
+    ],
+    [
+      "_expression",
+      "formal_parameters"
     ],
     [
       "_expression",
       "_property_definition_list"
     ],
     [
+      "labeled_statement",
+      "_property_name"
+    ],
+    [
       "assignment_pattern",
       "assignment"
-    ],
-    [
-      "yield_expression"
-    ],
-    [
-      "method_definition",
-      "reserved_identifier"
     ],
     [
       "required_parameter",
@@ -7230,39 +7165,6 @@
     [
       "_expression",
       "method_definition"
-    ],
-    [
-      "reserved_identifier",
-      "module"
-    ],
-    [
-      "reserved_identifier",
-      "reserved_identifier"
-    ],
-    [
-      "reserved_identifier",
-      "ambient_declaration"
-    ],
-    [
-      "reserved_identifier",
-      "interface_declaration"
-    ],
-    [
-      "reserved_identifier",
-      "internal_module"
-    ],
-    [
-      "reserved_identifier",
-      "abstract_method_definition"
-    ],
-    [
-      "reserved_identifier",
-      "public_field_definition",
-      "abstract_method_definition"
-    ],
-    [
-      "reserved_identifier",
-      "type_alias_declaration"
     ]
   ],
   "externals": [
@@ -7270,5 +7172,11 @@
       "type": "SYMBOL",
       "name": "_automatic_semicolon"
     }
+  ],
+  "inline": [
+    "_statement",
+    "_semicolon",
+    "_destructuring_pattern",
+    "_reserved_identifier"
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -27,17 +27,8 @@
               "name": "_from_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -57,17 +48,8 @@
               "name": "_from_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -83,17 +65,8 @@
               "name": "export_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -143,17 +116,8 @@
               "name": "_expression"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -173,17 +137,8 @@
               "name": "identifier"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -207,17 +162,8 @@
               "name": "identifier"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -330,7 +276,19 @@
         "members": [
           {
             "type": "SYMBOL",
+            "name": "export_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "import_alias"
+          },
+          {
+            "type": "SYMBOL",
             "name": "function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "internal_module"
           },
           {
             "type": "SYMBOL",
@@ -430,17 +388,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -4335,17 +4284,8 @@
                     "name": "public_field_definition"
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_automatic_semicolon"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ";"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_semicolon"
                   }
                 ]
               },
@@ -4357,17 +4297,8 @@
                     "name": "index_signature"
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_automatic_semicolon"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ";"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_semicolon"
                   }
                 ]
               }
@@ -4758,52 +4689,6 @@
         ]
       }
     },
-    "ambient_export_declaration": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "export"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "interface_declaration"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ambient_variable"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ambient_function"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "class"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_ambient_enum"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ambient_namespace"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "module"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "type_alias_declaration"
-            }
-          ]
-        }
-      ]
-    },
     "abstract_method_definition": {
       "type": "SEQ",
       "members": [
@@ -4881,17 +4766,8 @@
           "name": "call_signature"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -4911,17 +4787,8 @@
           "name": "call_signature"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -5054,41 +4921,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interface_declaration"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ambient_variable"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ambient_function"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "class"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_ambient_enum"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ambient_namespace"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "module"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "type_alias_declaration"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_declaration"
             },
             {
               "type": "SEQ",
@@ -5099,90 +4933,9 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "ambient_namespace_body"
+                  "name": "statement_block"
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    "ambient_variable": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "var"
-            },
-            {
-              "type": "STRING",
-              "value": "let"
-            },
-            {
-              "type": "STRING",
-              "value": "const"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "ambient_binding"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ambient_binding"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
             }
           ]
         }
@@ -5230,27 +4983,6 @@
         {
           "type": "SYMBOL",
           "name": "class_body"
-        }
-      ]
-    },
-    "_ambient_enum": {
-      "type": "SYMBOL",
-      "name": "enum_declaration"
-    },
-    "ambient_namespace": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "namespace"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_entity_name"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ambient_namespace_body"
         }
       ]
     },
@@ -5318,76 +5050,6 @@
         ]
       }
     },
-    "ambient_namespace_body": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "ambient_export_declaration"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "interface_declaration"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ambient_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ambient_function"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "class"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_ambient_enum"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ambient_namespace"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "module"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "type_alias_declaration"
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "lexical_declaration"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "import_alias"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
-    },
     "import_alias": {
       "type": "SEQ",
       "members": [
@@ -5408,17 +5070,8 @@
           "name": "_entity_name"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -5450,27 +5103,6 @@
           }
         ]
       }
-    },
-    "ambient_binding": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_annotation"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
     },
     "interface_declaration": {
       "type": "SEQ",
@@ -5697,17 +5329,8 @@
           "name": "_type"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -5804,17 +5427,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_destructuring_pattern"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_destructuring_pattern"
                 },
                 {
                   "type": "SYMBOL",
@@ -5851,101 +5469,58 @@
       ]
     },
     "optional_parameter": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "accessibility_modifier"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "accessibility_modifier"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_destructuring_pattern"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "?"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type_annotation"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "accessibility_modifier"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_destructuring_pattern"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "?"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type_annotation"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "SYMBOL",
+              "name": "_destructuring_pattern"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_annotation"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
               "name": "_initializer"
+            },
+            {
+              "type": "BLANK"
             }
           ]
         }
@@ -6380,17 +5955,8 @@
                             "value": ","
                           },
                           {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "_automatic_semicolon"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ";"
-                              }
-                            ]
+                            "type": "SYMBOL",
+                            "name": "_semicolon"
                           }
                         ]
                       },
@@ -6414,17 +5980,8 @@
                       "value": ","
                     },
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_automatic_semicolon"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "_semicolon"
                     }
                   ]
                 },
@@ -6445,7 +6002,7 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "ambient_export_declaration"
+            "name": "export_statement"
           },
           {
             "type": "SYMBOL",
@@ -7072,10 +6629,6 @@
       "_entity_name"
     ],
     [
-      "ambient_binding",
-      "variable_declarator"
-    ],
-    [
       "_expression",
       "type_query"
     ],
@@ -7098,10 +6651,6 @@
     ],
     [
       "type_reference"
-    ],
-    [
-      "export_statement",
-      "ambient_export_declaration"
     ],
     [
       "function_call",
@@ -7161,10 +6710,6 @@
     [
       "_expression",
       "import_alias"
-    ],
-    [
-      "_expression",
-      "method_definition"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4816,16 +4816,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_expression"
           },
           {
             "type": "STRING",
@@ -4888,7 +4880,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "type_reference"
+              "name": "_type"
             },
             {
               "type": "REPEAT",
@@ -4901,7 +4893,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "type_reference"
+                    "name": "_type"
                   }
                 ]
               }
@@ -5031,7 +5023,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_entity_name"
+                "name": "nested_identifier"
               }
             ]
           },
@@ -5066,8 +5058,17 @@
           "value": "="
         },
         {
-          "type": "SYMBOL",
-          "name": "_entity_name"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nested_identifier"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -5076,30 +5077,79 @@
       ]
     },
     "_entity_name": {
-      "type": "PREC_RIGHT",
-      "value": 0,
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nested_identifier"
+        }
+      ]
+    },
+    "nested_identifier": {
+      "type": "PREC",
+      "value": 13,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "nested_identifier"
+              }
+            ]
           },
           {
-            "type": "REPEAT",
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        ]
+      }
+    },
+    "nested_type_identifier": {
+      "type": "PREC",
+      "value": 12,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "nested_identifier"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "ALIAS",
             "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "."
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              ]
-            }
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            "named": true,
+            "value": "type_identifier"
           }
         ]
       }
@@ -5157,7 +5207,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "type_reference"
+              "name": "_type"
             },
             {
               "type": "REPEAT",
@@ -5170,7 +5220,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "type_reference"
+                    "name": "_type"
                   }
                 ]
               }
@@ -5376,35 +5426,6 @@
         }
       ]
     },
-    "parameter_identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "any"
-        },
-        {
-          "type": "STRING",
-          "value": "number"
-        },
-        {
-          "type": "STRING",
-          "value": "boolean"
-        },
-        {
-          "type": "STRING",
-          "value": "string"
-        },
-        {
-          "type": "STRING",
-          "value": "symbol"
-        },
-        {
-          "type": "STRING",
-          "value": "void"
-        }
-      ]
-    },
     "required_parameter": {
       "type": "CHOICE",
       "members": [
@@ -5431,12 +5452,42 @@
                   "name": "identifier"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_destructuring_pattern"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "any"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "number"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "boolean"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "string"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "symbol"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "void"
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "identifier"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "parameter_identifier"
+                  "name": "_destructuring_pattern"
                 }
               ]
             },
@@ -5643,8 +5694,21 @@
           "name": "predefined_type"
         },
         {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "named": true,
+          "value": "type_identifier"
+        },
+        {
           "type": "SYMBOL",
-          "name": "type_reference"
+          "name": "nested_type_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generic_type"
         },
         {
           "type": "SYMBOL",
@@ -5688,6 +5752,33 @@
         }
       ]
     },
+    "generic_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "named": true,
+              "value": "type_identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nested_type_identifier"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_arguments"
+        }
+      ]
+    },
     "type_predicate": {
       "type": "SEQ",
       "members": [
@@ -5706,17 +5797,30 @@
       ]
     },
     "type_query": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "typeof"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_entity_name"
-        }
-      ]
+      "type": "PREC",
+      "value": 7,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "typeof"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "nested_identifier"
+              }
+            ]
+          }
+        ]
+      }
     },
     "index_type_query": {
       "type": "SEQ",
@@ -5726,8 +5830,17 @@
           "value": "keyof"
         },
         {
-          "type": "SYMBOL",
-          "name": "_entity_name"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nested_identifier"
+            }
+          ]
         }
       ]
     },
@@ -5858,27 +5971,6 @@
         {
           "type": "STRING",
           "value": ">"
-        }
-      ]
-    },
-    "type_reference": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_entity_name"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_arguments"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },
@@ -6547,8 +6639,43 @@
       "assignment"
     ],
     [
-      "required_parameter",
-      "assignment"
+      "function_call",
+      "rel_op",
+      "type_op"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "type_query"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "new_expression"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "bool_op"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "bitwise_op"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "math_op"
+    ],
+    [
+      "function_call",
+      "rel_op",
+      "void_op"
+    ],
+    [
+      "generic_type",
+      "_primary_type"
     ],
     [
       "required_parameter",
@@ -6556,160 +6683,61 @@
     ],
     [
       "required_parameter",
+      "_expression",
       "_primary_type"
     ],
     [
-      "identifier",
+      "required_parameter",
+      "assignment"
+    ],
+    [
+      "optional_parameter",
+      "_expression"
+    ],
+    [
+      "required_parameter",
       "predefined_type"
     ],
     [
-      "_expression",
-      "optional_parameter"
+      "required_parameter",
+      "_primary_type"
+    ],
+    [
+      "_primary_type",
+      "type_parameter"
+    ],
+    [
+      "jsx_opening_element",
+      "_primary_type",
+      "type_parameter"
     ],
     [
       "_expression",
       "literal_type"
     ],
     [
-      "method_signature",
-      "method_definition",
-      "_expression"
-    ],
-    [
-      "_expression",
-      "_type_member",
-      "method_signature"
-    ],
-    [
       "_expression",
       "_primary_type"
     ],
     [
       "_expression",
-      "required_parameter",
-      "_primary_type"
-    ],
-    [
-      "_expression",
-      "property_signature"
-    ],
-    [
-      "_expression",
-      "property_signature",
-      "method_signature"
-    ],
-    [
-      "_expression",
-      "property_signature",
-      "_property_definition_list"
-    ],
-    [
-      "property_signature",
-      "_property_definition_list"
-    ],
-    [
-      "jsx_opening_element",
-      "type_parameter"
+      "generic_type"
     ],
     [
       "this_type",
       "this_expression"
     ],
     [
-      "required_parameter",
-      "_entity_name"
-    ],
-    [
-      "_expression",
-      "required_parameter",
-      "_entity_name"
-    ],
-    [
-      "_expression",
-      "_entity_name"
-    ],
-    [
-      "_expression",
-      "type_query"
-    ],
-    [
-      "parameter_identifier",
-      "predefined_type"
-    ],
-    [
-      "_entity_name",
-      "type_parameter"
-    ],
-    [
-      "jsx_opening_element",
-      "_entity_name"
-    ],
-    [
-      "jsx_opening_element",
-      "_entity_name",
-      "type_parameter"
-    ],
-    [
-      "type_reference"
-    ],
-    [
-      "function_call",
-      "math_op",
-      "rel_op"
-    ],
-    [
-      "function_call",
-      "bitwise_op",
-      "rel_op"
-    ],
-    [
-      "function_call",
-      "void_op",
-      "rel_op"
-    ],
-    [
-      "function_call",
-      "new_expression",
-      "rel_op"
-    ],
-    [
-      "function_call",
-      "bool_op",
-      "rel_op"
-    ],
-    [
-      "function_call",
-      "rel_op",
-      "type_op"
-    ],
-    [
-      "_expression",
-      "method_signature"
-    ],
-    [
-      "_property_definition_list",
-      "_property_name"
-    ],
-    [
-      "_property_definition_list",
-      "_property_name",
-      "_expression"
-    ],
-    [
-      "call_signature",
-      "function_type"
+      "function_type",
+      "call_signature"
     ],
     [
       "constructor_type",
       "call_signature"
     ],
     [
-      "_module",
-      "_entity_name"
-    ],
-    [
-      "_expression",
-      "import_alias"
+      "_property_name",
+      "_property_definition_list"
     ]
   ],
   "externals": [

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -8,8 +8,8 @@ enum TokenType {
 void *tree_sitter_typescript_external_scanner_create() { return NULL; }
 void tree_sitter_typescript_external_scanner_destroy(void *payload) {}
 void tree_sitter_typescript_external_scanner_reset(void *payload) {}
-bool tree_sitter_typescript_external_scanner_serialize(void *payload, TSExternalTokenState state) { return true; }
-void tree_sitter_typescript_external_scanner_deserialize(void *payload, TSExternalTokenState state) {}
+unsigned tree_sitter_typescript_external_scanner_serialize(void *payload, char *state) { return 0; }
+void tree_sitter_typescript_external_scanner_deserialize(void *payload, const char *state, unsigned length) {}
 
 static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -9,13 +9,12 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef unsigned short TSSymbol;
-typedef unsigned short TSStateId;
-
-typedef uint8_t TSExternalTokenState[16];
+typedef uint16_t TSSymbol;
+typedef uint16_t TSStateId;
 
 #define ts_builtin_sym_error ((TSSymbol)-1)
 #define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
 typedef struct {
   bool visible : 1;
@@ -40,15 +39,19 @@ typedef enum {
 
 typedef struct {
   union {
-    TSStateId to_state;
+    struct {
+      TSStateId state;
+      bool extra : 1;
+    };
     struct {
       TSSymbol symbol;
-      unsigned short child_count;
+      int16_t dynamic_precedence;
+      uint8_t child_count;
+      uint8_t alias_sequence_id : 7;
+      bool fragile : 1;
     };
   } params;
   TSParseActionType type : 4;
-  bool extra : 1;
-  bool fragile : 1;
 } TSParseAction;
 
 typedef struct {
@@ -59,7 +62,7 @@ typedef struct {
 typedef union {
   TSParseAction action;
   struct {
-    unsigned short count;
+    uint8_t count;
     bool reusable : 1;
     bool depends_on_lookahead : 1;
   };
@@ -68,23 +71,25 @@ typedef union {
 typedef struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
+  uint32_t alias_count;
   uint32_t token_count;
   uint32_t external_token_count;
   const char **symbol_names;
   const TSSymbolMetadata *symbol_metadata;
-  const unsigned short *parse_table;
+  const uint16_t *parse_table;
   const TSParseActionEntry *parse_actions;
   const TSLexMode *lex_modes;
+  const TSSymbol *alias_sequences;
+  uint16_t max_alias_sequence_length;
   bool (*lex_fn)(TSLexer *, TSStateId);
   struct {
     const bool *states;
     const TSSymbol *symbol_map;
     void *(*create)();
     void (*destroy)(void *);
-    void (*reset)(void *);
     bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
-    bool (*serialize)(void *, TSExternalTokenState);
-    void (*deserialize)(void *, const TSExternalTokenState);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
 } TSLanguage;
 
@@ -126,39 +131,40 @@ typedef struct TSLanguage {
 #define STATE(id) id
 #define ACTIONS(id) id
 
-#define SHIFT(to_state_value)                                                 \
-  {                                                                           \
-    {                                                                         \
-      .type = TSParseActionTypeShift, .params = {.to_state = to_state_value } \
-    }                                                                         \
+#define SHIFT(state_value)              \
+  {                                     \
+    {                                   \
+      .type = TSParseActionTypeShift,   \
+      .params = {.state = state_value}, \
+    }                                   \
   }
 
-#define RECOVER(to_state_value)                                                 \
-  {                                                                             \
-    {                                                                           \
-      .type = TSParseActionTypeRecover, .params = {.to_state = to_state_value } \
-    }                                                                           \
+#define RECOVER(state_value)            \
+  {                                     \
+    {                                   \
+      .type = TSParseActionTypeRecover, \
+      .params = {.state = state_value}  \
+    }                                   \
   }
 
-#define SHIFT_EXTRA()                                 \
-  {                                                   \
-    { .type = TSParseActionTypeShift, .extra = true } \
+#define SHIFT_EXTRA()                 \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .params = {.extra = true}       \
+    }                                 \
   }
 
-#define REDUCE(symbol_val, child_count_val)                             \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce,                                  \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
-    }                                                                   \
-  }
-
-#define REDUCE_FRAGILE(symbol_val, child_count_val)                     \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce, .fragile = true,                 \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
-    }                                                                   \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {                                              \
+    {                                            \
+      .type = TSParseActionTypeReduce,           \
+      .params = {                                \
+        .symbol = symbol_val,                    \
+        .child_count = child_count_val,          \
+        __VA_ARGS__                              \
+      }                                          \
+    }                                            \
   }
 
 #define ACCEPT_INPUT()                  \
@@ -166,21 +172,24 @@ typedef struct TSLanguage {
     { .type = TSParseActionTypeAccept } \
   }
 
-#define GET_LANGUAGE(...)                                          \
-  static TSLanguage language = {                                   \
-    .version = LANGUAGE_VERSION,                                   \
-    .symbol_count = SYMBOL_COUNT,                                  \
-    .token_count = TOKEN_COUNT,                                    \
-    .symbol_metadata = ts_symbol_metadata,                         \
-    .parse_table = (const unsigned short *)ts_parse_table,         \
-    .parse_actions = ts_parse_actions,                             \
-    .lex_modes = ts_lex_modes,                                     \
-    .symbol_names = ts_symbol_names,                               \
-    .lex_fn = ts_lex,                                              \
-    .external_token_count = EXTERNAL_TOKEN_COUNT,                  \
-    .external_scanner = {__VA_ARGS__}                              \
-  };                                                               \
-  return &language                                                 \
+#define GET_LANGUAGE(...)                                    \
+  static TSLanguage language = {                             \
+    .version = LANGUAGE_VERSION,                             \
+    .symbol_count = SYMBOL_COUNT,                            \
+    .alias_count = ALIAS_COUNT,                              \
+    .token_count = TOKEN_COUNT,                              \
+    .symbol_metadata = ts_symbol_metadata,                   \
+    .parse_table = (const unsigned short *)ts_parse_table,   \
+    .parse_actions = ts_parse_actions,                       \
+    .lex_modes = ts_lex_modes,                               \
+    .symbol_names = ts_symbol_names,                         \
+    .alias_sequences = (const TSSymbol *)ts_alias_sequences, \
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,  \
+    .lex_fn = ts_lex,                                        \
+    .external_token_count = EXTERNAL_TOKEN_COUNT,            \
+    .external_scanner = {__VA_ARGS__}                        \
+  };                                                         \
+  return &language                                           \
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR updates the typescript grammar to:

1. Work with the new JavaScript grammar
2. Compile against the newest version of tree-sitter
3. Distinguish between types, properties, and regular identifiers using tree-sitter's new `alias` API

We also simplified the grammar somewhat by removing some of the duplication between ambient declarations and their non-ambient counterparts.

🍐 'd with @rewinfrey 
