### PR TITLE
Add optional trailing semicolons to method definitions

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -541,6 +541,34 @@ class Foo {
       (public_field_definition (readonly) (string) (type_annotation (type_identifier)) (string))))))
 
 =======================================
+Classes with methods with and without trailing semicolons on one line
+=======================================
+
+class Foo<Bar> extends Baz { bar = 5; static one(a) { return a; }; two(b) { return b; } three(c) { return c; } }
+
+---
+
+(program
+  (expression_statement
+    (class
+      (identifier)
+      (type_parameters (type_parameter (identifier)))
+      (class_heritage (extends_clause (type_identifier)))
+      (class_body
+        (public_field_definition (property_identifier) (number))
+        (method_definition (property_identifier)
+          (call_signature (formal_parameters (required_parameter (identifier))))
+          (statement_block (return_statement (identifier))))
+        (method_definition
+          (property_identifier)
+          (call_signature (formal_parameters (required_parameter (identifier))))
+          (statement_block (return_statement (identifier))))
+        (method_definition
+          (property_identifier)
+          (call_signature (formal_parameters (required_parameter (identifier))))
+          (statement_block (return_statement (identifier))))))))
+
+=======================================
 Global namespace declarations
 =======================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -187,8 +187,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       '{',
       repeat(
         choice(
-          $.method_definition,
           $.abstract_method_definition,
+          seq($.method_definition, optional($._semicolon)),
           seq($.index_signature, $._semicolon),
           seq($.method_signature, $._semicolon),
           seq($.public_field_definition, $._semicolon)
@@ -205,8 +205,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       optional(choice('get', 'set', '*')),
       $._property_name,
       $.call_signature,
-      $.statement_block,
-      $._semicolon
+      $.statement_block
     )),
 
     _declaration: ($, previous) => prec(PREC.DECLARATION, choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4110,8 +4110,25 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "method_definition"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "method_definition"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_semicolon"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -4420,10 +4437,6 @@
           {
             "type": "SYMBOL",
             "name": "statement_block"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_semicolon"
           }
         ]
       }


### PR DESCRIPTION
Since method definitions can appear on one line, we need to make trailing semicolons optional.