### PR TITLE
Typescript fixes

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -638,22 +638,20 @@ abstract class Animal {
 ---
 
 (program
-  (expression_statement
-    (abstract_class (identifier) (class_body)))
-  (expression_statement
-    (abstract_class (identifier) (class_body
-      (public_field_definition (property_identifier) (type_annotation (predefined_type)))
-      (public_field_definition (property_identifier) (type_annotation (predefined_type)))
-      (abstract_method_definition
-        (property_identifier)
-        (call_signature (formal_parameters) (type_annotation (predefined_type))))
-      (abstract_method_definition
-        (property_identifier)
-        (call_signature (formal_parameters) (type_annotation (predefined_type))))
-      (method_definition
-        (property_identifier)
-        (call_signature (formal_parameters) (type_annotation (predefined_type)))
-        (statement_block
-          (expression_statement (call_expression
-            (member_expression (identifier) (property_identifier))
-            (arguments (string))))))))))
+  (abstract_class (identifier) (class_body))
+  (abstract_class (identifier) (class_body
+    (public_field_definition (property_identifier) (type_annotation (predefined_type)))
+    (public_field_definition (property_identifier) (type_annotation (predefined_type)))
+    (abstract_method_definition
+      (property_identifier)
+      (call_signature (formal_parameters) (type_annotation (predefined_type))))
+    (abstract_method_definition
+      (property_identifier)
+      (call_signature (formal_parameters) (type_annotation (predefined_type))))
+    (method_definition
+      (property_identifier)
+      (call_signature (formal_parameters) (type_annotation (predefined_type)))
+      (statement_block
+        (expression_statement (call_expression
+          (member_expression (identifier) (property_identifier))
+          (arguments (string)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -330,7 +330,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     extends_clause: $ => seq(
       'extends',
-      sepBy1(',', $._type)
+      $._expression,
+      optional($.type_arguments)
     ),
 
     enum_declaration: $ => seq(
@@ -527,7 +528,13 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     type_parameter: $ => seq(
       $.identifier,
-      optional($.constraint)
+      optional($.constraint),
+      optional($.default_type)
+    ),
+
+    default_type: $ => seq(
+      '=',
+      $._type
     ),
 
     constraint: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -81,7 +81,6 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.non_null_expression,
       $.internal_module,
       $.super,
-      $.abstract_class,
       previous
     ),
 
@@ -221,6 +220,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.internal_module,
       $.ambient_function,
       $.generator_function,
+      $.abstract_class,
       $.class,
       $.module,
       $.variable_declaration,

--- a/grammar.js
+++ b/grammar.js
@@ -150,6 +150,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
           $.rest_parameter,
           $.optional_parameter
       ))),
+      optional(','),
       ')'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -8,6 +8,7 @@ const PREC = {
   REL: 5,
   TIMES: 6,
   TYPEOF: 7,
+  EXTENDS: 7,
   NEG: 9,
   INC: 10,
   NON_NULL: 10,
@@ -328,11 +329,11 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.object_type
     ),
 
-    extends_clause: $ => seq(
+    extends_clause: $ => prec(PREC.EXTENDS, seq(
       'extends',
-      $._expression,
+      choice(alias($.identifier, $.type_identifier), $._expression),
       optional($.type_arguments)
-    ),
+    )),
 
     enum_declaration: $ => seq(
       optional('const'),

--- a/grammar.js
+++ b/grammar.js
@@ -29,6 +29,9 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$.call_expression, $.binary_expression, $.new_expression],
     [$.call_expression, $.binary_expression, $.update_expression],
 
+    [$.nested_type_identifier, $.nested_identifier],
+    [$.nested_type_identifier, $.member_expression],
+
     [$.generic_type, $._primary_type],
 
     [$.member_expression, $.nested_identifier],
@@ -311,7 +314,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.identifier
     )),
 
-    nested_type_identifier: $ => prec(PREC.MEMBER - 1, seq(
+    nested_type_identifier: $ => prec(PREC.MEMBER, seq(
       choice($.identifier, $.nested_identifier),
       '.',
       alias($.identifier, $.type_identifier)

--- a/grammar.js
+++ b/grammar.js
@@ -376,6 +376,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     required_parameter: $ => choice(
       seq(
         optional($.accessibility_modifier),
+        optional($.readonly),
         choice(
           $.identifier,
           alias($._reserved_identifier, $.identifier),
@@ -388,6 +389,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     optional_parameter: $ => seq(
       optional($.accessibility_modifier),
+      optional($.readonly),
       choice($.identifier, alias($._reserved_identifier, $.identifier), $._destructuring_pattern),
       '?',
       optional($.type_annotation),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4642,6 +4642,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": ")"
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5489,29 +5489,47 @@
       ]
     },
     "extends_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "extends"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_arguments"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC",
+      "value": 7,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "extends"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                "named": true,
+                "value": "type_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_arguments"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "enum_declaration": {
       "type": "SEQ",
@@ -6856,7 +6874,7 @@
     },
     {
       "type": "PATTERN",
-      "value": "[\\s﻿⁠​]"
+      "value": "[\\s﻿⁠​ ]"
     }
   ],
   "conflicts": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5414,7 +5414,7 @@
     },
     "nested_type_identifier": {
       "type": "PREC",
-      "value": 12,
+      "value": 13,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6879,6 +6879,14 @@
       "call_expression",
       "binary_expression",
       "update_expression"
+    ],
+    [
+      "nested_type_identifier",
+      "nested_identifier"
+    ],
+    [
+      "nested_type_identifier",
+      "member_expression"
     ],
     [
       "generic_type",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5725,6 +5725,18 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "readonly"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
                   "name": "identifier"
                 },
                 {
@@ -5779,6 +5791,18 @@
             {
               "type": "SYMBOL",
               "name": "accessibility_modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "readonly"
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5496,27 +5496,18 @@
           "value": "extends"
         },
         {
-          "type": "SEQ",
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_type"
+              "name": "type_arguments"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_type"
-                  }
-                ]
-              }
+              "type": "BLANK"
             }
           ]
         }
@@ -6577,6 +6568,31 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "default_type"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "default_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -298,6 +298,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "abstract_class"
+          },
+          {
+            "type": "SYMBOL",
             "name": "class"
           },
           {
@@ -1511,10 +1515,6 @@
         {
           "type": "SYMBOL",
           "name": "super"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "abstract_class"
         },
         {
           "type": "CHOICE",


### PR DESCRIPTION
- [x] Allow abstract classes as declarations
- [x] Allow trailing commas in formal parameters
- [x] Add conflict between member expression and nested type identifier (So call expressions can be annotated with nested types)
- [x] Allow parameters to have accessibility and readonly modifiers
- [x] Add optional `default_type` to `type_argument`