### PR TITLE
Allow extends clauses to have multiple interfaces

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -247,6 +247,10 @@ interface X {
   get(key: Key): Promise<T>;
 }
 
+interface Enum extends Bar, Baz, funThatEvalsToInterface() {
+  public toEnum(): Int;
+}
+
 ---
 
 (program
@@ -278,7 +282,18 @@ interface X {
           (formal_parameters
             (required_parameter (identifier) (type_annotation (type_identifier))))
           (type_annotation
-            (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
+            (generic_type (type_identifier) (type_arguments (type_identifier))))))))
+  (interface_declaration
+    (identifier)
+    (extends_clause
+      (type_identifier)
+      (type_identifier)
+      (call_expression (identifier) (arguments)))
+      (object_type
+        (method_signature
+          (accessibility_modifier)
+          (property_identifier)
+          (call_signature (formal_parameters) (type_annotation (type_identifier)))))))
 
 =======================================
 Existential types

--- a/grammar.js
+++ b/grammar.js
@@ -16,7 +16,8 @@ const PREC = {
   ARRAY_TYPE: 13,
   MEMBER: 13,
   AS_EXPRESSION: 14,
-  TYPE_ASSERTION: 15
+  TYPE_ASSERTION: 15,
+  TYPE_REFERENCE: 15
 };
 
 module.exports = grammar(require('tree-sitter-javascript/grammar'), {
@@ -327,10 +328,15 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.object_type
     ),
 
+    _type_reference: $ => prec(PREC.TYPE_REFERENCE, choice(
+      alias($.identifier, $.type_identifier),
+      $.nested_type_identifier,
+      $.generic_type
+    )),
+
     extends_clause: $ => prec(PREC.EXTENDS, seq(
       'extends',
-      choice(alias($.identifier, $.type_identifier), $._expression),
-      optional($.type_arguments)
+      choice($._type_reference, $._expression)
     )),
 
     enum_declaration: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -336,7 +336,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     extends_clause: $ => prec(PREC.EXTENDS, seq(
       'extends',
-      choice($._type_reference, $._expression)
+      commaSep1(choice($._type_reference, $._expression))
     )),
 
     enum_declaration: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5631,15 +5631,45 @@
             "value": "extends"
           },
           {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_type_reference"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type_reference"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "_expression"
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_type_reference"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expression"
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5594,6 +5594,32 @@
         }
       ]
     },
+    "_type_reference": {
+      "type": "PREC",
+      "value": 15,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            "named": true,
+            "value": "type_identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "nested_type_identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "generic_type"
+          }
+        ]
+      }
+    },
     "extends_clause": {
       "type": "PREC",
       "value": 7,
@@ -5608,29 +5634,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                "named": true,
-                "value": "type_identifier"
+                "type": "SYMBOL",
+                "name": "_type_reference"
               },
               {
                 "type": "SYMBOL",
                 "name": "_expression"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "type_arguments"
-              },
-              {
-                "type": "BLANK"
               }
             ]
           }


### PR DESCRIPTION
Seems like this was lost when allowing expressions in extends clauses.