### PR TITLE
Allow this to be a parameter

### DIFF
--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -142,4 +142,4 @@ class A extends B {
             (return_statement
               (binary_expression
                 (binary_expression (call_expression (member_expression (super) (property_identifier)) (arguments)) (string))
-                (member_expression (this_expression) (property_identifier))))))))))
+                (member_expression (identifier) (property_identifier))))))))))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -142,4 +142,4 @@ class A extends B {
             (return_statement
               (binary_expression
                 (binary_expression (call_expression (member_expression (super) (property_identifier)) (arguments)) (string))
-                (member_expression (identifier) (property_identifier))))))))))
+                (member_expression (this) (property_identifier))))))))))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -14,6 +14,10 @@ function foo<T, U>(a: T[], f: (x: T) => U): U[] {
 
 }
 
+function foo<T, U>(this: T[]): U[] {
+  return []
+}
+
 ---
 
 (program
@@ -44,7 +48,16 @@ function foo<T, U>(a: T[], f: (x: T) => U): U[] {
               (function_type
                 (formal_parameters (required_parameter (identifier) (type_annotation (type_identifier)))) (type_identifier)))))
         (type_annotation (array_type (type_identifier))))
-      (statement_block))))
+      (statement_block)))
+  (expression_statement
+    (function
+      (identifier)
+      (call_signature
+        (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
+        (formal_parameters
+          (required_parameter (this) (type_annotation (array_type (type_identifier)))))
+          (type_annotation (array_type (type_identifier))))
+      (statement_block (return_statement (array))))))
 
 ==================================
 Function calls with type arguments

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -62,6 +62,8 @@ Function types
 =======================================
 
 let x: (result: string) => any;
+const foo: (this: Readable, size?: number) => any;
+
 
 ---
 
@@ -72,6 +74,14 @@ let x: (result: string) => any;
       (function_type
         (formal_parameters
           (required_parameter (identifier) (type_annotation (predefined_type))))
+        (predefined_type)))))
+  (lexical_declaration (variable_declarator
+    (identifier)
+    (type_annotation
+      (function_type
+        (formal_parameters
+          (required_parameter (identifier) (type_annotation (type_identifier)))
+          (optional_parameter (identifier) (type_annotation (predefined_type))))
         (predefined_type))))))
 
 =======================================

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -80,7 +80,7 @@ const foo: (this: Readable, size?: number) => any;
     (type_annotation
       (function_type
         (formal_parameters
-          (required_parameter (identifier) (type_annotation (type_identifier)))
+          (required_parameter (this) (type_annotation (type_identifier)))
           (optional_parameter (identifier) (type_annotation (predefined_type))))
         (predefined_type))))))
 

--- a/grammar.js
+++ b/grammar.js
@@ -55,6 +55,13 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$._expression, $.generic_type],
     [$._expression, $.predefined_type],
     [$.this_type, $.this_expression],
+    [$._expression, $.this_expression],
+    [$._expression, $.this_expression, $.this_type],
+    [$._expression, $.this_expression, $.required_parameter, $.this_type],
+    [$._expression, $.this_expression, $._property_name],
+    [$._expression, $.this_expression, $.required_parameter],
+    [$._expression, $.this_expression, $.optional_parameter],
+    [$.this_type, $.required_parameter],
     [$.function_type, $.call_signature],
     [$.constructor_type, $.call_signature],
 
@@ -597,6 +604,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       'void',
       'import',
       'export',
+      'this',
       previous
     )
   }

--- a/grammar.js
+++ b/grammar.js
@@ -399,8 +399,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       choice(
         $.identifier,
         alias($._reserved_identifier, $.identifier),
-        $._destructuring_pattern,
-        $.this
+        $._destructuring_pattern
       ),
       '?',
       optional($.type_annotation),

--- a/grammar.js
+++ b/grammar.js
@@ -54,14 +54,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$._expression, $._primary_type],
     [$._expression, $.generic_type],
     [$._expression, $.predefined_type],
-    [$.this_type, $.this_expression],
-    [$._expression, $.this_expression],
-    [$._expression, $.this_expression, $.this_type],
-    [$._expression, $.this_expression, $.required_parameter, $.this_type],
-    [$._expression, $.this_expression, $._property_name],
-    [$._expression, $.this_expression, $.required_parameter],
-    [$._expression, $.this_expression, $.optional_parameter],
-    [$.this_type, $.required_parameter],
+    [$.this_type, $.this],
     [$.function_type, $.call_signature],
     [$.constructor_type, $.call_signature],
 
@@ -392,7 +385,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
         choice(
           $.identifier,
           alias($._reserved_identifier, $.identifier),
-          $._destructuring_pattern
+          $._destructuring_pattern,
+          $.this
         ),
         optional($.type_annotation),
         optional($._initializer)
@@ -402,7 +396,12 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     optional_parameter: $ => seq(
       optional($.accessibility_modifier),
       optional($.readonly),
-      choice($.identifier, alias($._reserved_identifier, $.identifier), $._destructuring_pattern),
+      choice(
+        $.identifier,
+        alias($._reserved_identifier, $.identifier),
+        $._destructuring_pattern,
+        $.this
+      ),
       '?',
       optional($.type_annotation),
       optional($._initializer)
@@ -604,7 +603,6 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       'void',
       'import',
       'export',
-      'this',
       previous
     )
   }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4985,6 +4985,10 @@
           "value": "export"
         },
         {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -7136,6 +7140,40 @@
     [
       "this_type",
       "this_expression"
+    ],
+    [
+      "_expression",
+      "this_expression"
+    ],
+    [
+      "_expression",
+      "this_expression",
+      "this_type"
+    ],
+    [
+      "_expression",
+      "this_expression",
+      "required_parameter",
+      "this_type"
+    ],
+    [
+      "_expression",
+      "this_expression",
+      "_property_name"
+    ],
+    [
+      "_expression",
+      "this_expression",
+      "required_parameter"
+    ],
+    [
+      "_expression",
+      "this_expression",
+      "optional_parameter"
+    ],
+    [
+      "this_type",
+      "required_parameter"
     ],
     [
       "function_type",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1607,7 +1607,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "this_expression"
+              "name": "this"
             },
             {
               "type": "SYMBOL",
@@ -4183,7 +4183,7 @@
       "type": "PATTERN",
       "value": "[\\a_$][\\a\\d_$]*"
     },
-    "this_expression": {
+    "this": {
       "type": "STRING",
       "value": "this"
     },
@@ -4983,10 +4983,6 @@
         {
           "type": "STRING",
           "value": "export"
-        },
-        {
-          "type": "STRING",
-          "value": "this"
         },
         {
           "type": "CHOICE",
@@ -5897,6 +5893,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "_destructuring_pattern"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "this"
                 }
               ]
             },
@@ -5974,6 +5974,10 @@
             {
               "type": "SYMBOL",
               "name": "_destructuring_pattern"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "this"
             }
           ]
         },
@@ -7139,41 +7143,7 @@
     ],
     [
       "this_type",
-      "this_expression"
-    ],
-    [
-      "_expression",
-      "this_expression"
-    ],
-    [
-      "_expression",
-      "this_expression",
-      "this_type"
-    ],
-    [
-      "_expression",
-      "this_expression",
-      "required_parameter",
-      "this_type"
-    ],
-    [
-      "_expression",
-      "this_expression",
-      "_property_name"
-    ],
-    [
-      "_expression",
-      "this_expression",
-      "required_parameter"
-    ],
-    [
-      "_expression",
-      "this_expression",
-      "optional_parameter"
-    ],
-    [
-      "this_type",
-      "required_parameter"
+      "this"
     ],
     [
       "function_type",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5974,10 +5974,6 @@
             {
               "type": "SYMBOL",
               "name": "_destructuring_pattern"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "this"
             }
           ]
         },


### PR DESCRIPTION
It looks like `this` is a valid parameter identifier in TypeScript but not JavaScript. This PR adds it to the `_reserved_identifier` list and adds conflicts between `this_expression`, `_expression`, `this_type`, `required_parameter`, and `optional_parameter`. 

One of the `Super` tests changed from matching an identifier as a `this_expression` to an `identifier` with this change. It seems that in that case, it should be a `this_expression` but it really depends on whether `this` shadowed by a parameter or not. We could make `this_expression` have a higher precedence than `_expression`, but then wouldn’t arguments to a function parse as `identifier` and uses parse as `this_expression`? What do you think @maxbrunsfeld?