### PR TITLE
Fix bug with subscript expressions to reserved identifiers in if statements

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -82,3 +82,23 @@ i < string.length;
   (expression_statement (binary_expression (identifier) (member_expression (identifier) (property_identifier))))
   (expression_statement (binary_expression (identifier) (member_expression (identifier) (property_identifier))))
   (expression_statement (binary_expression (identifier) (member_expression (identifier) (property_identifier)))))
+
+=====================================
+Subscript expressions in if statements
+=====================================
+
+if ( foo ) {
+	set[ 1 ].apply()
+}
+
+---
+
+(program
+  (if_statement
+    (parenthesized_expression (identifier))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (member_expression
+            (subscript_expression (identifier) (number)) (property_identifier))
+          (arguments))))))

--- a/grammar.js
+++ b/grammar.js
@@ -211,7 +211,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       '}'
     ),
 
-    method_definition: $ => prec.left(PREC.DEFINITION, seq(
+    method_definition: $ => prec.left(seq(
       optional($.accessibility_modifier),
       optional('static'),
       optional($.readonly),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4697,7 +4697,7 @@
     },
     "method_definition": {
       "type": "PREC_LEFT",
-      "value": 1,
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [


### PR DESCRIPTION
Since method definitions had a higher precedence, we were failing to parse subscript expressions in if-statements.