### PR TITLE
Add support for lookup types

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -488,7 +488,7 @@ type K1 = typeof Person;
     (type_query (identifier))))
 
 =======================================
-Type query and index type query types
+Lookup types
 =======================================
 
 type K1 = Foo[bar]
@@ -502,4 +502,4 @@ type K1 = Foo['bar' | 'baz']
     (lookup_type (identifier) (type_identifier)))
   (type_alias_declaration
     (identifier)
-    (lookup_type (identifier) (union_type (literal_type (string)) (literal_type (string)))))) 
+    (lookup_type (identifier) (union_type (literal_type (string)) (literal_type (string))))))

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -34,7 +34,7 @@ Object types
 =======================================
 
 let person: {name: string, age: number};
-
+let thing: { [type: string]: string };
 ---
 
 (program
@@ -42,7 +42,11 @@ let person: {name: string, age: number};
     (identifier)
     (type_annotation (object_type
       (property_signature (property_identifier) (type_annotation (predefined_type)))
-      (property_signature (property_identifier) (type_annotation (predefined_type))))))))
+      (property_signature (property_identifier) (type_annotation (predefined_type)))))))
+  (lexical_declaration (variable_declarator
+    (identifier)
+    (type_annotation (object_type
+      (index_signature (identifier) (type_annotation (predefined_type))))))))
 
 =======================================
 Array types

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -486,3 +486,20 @@ type K1 = typeof Person;
   (type_alias_declaration
     (identifier)
     (type_query (identifier))))
+
+=======================================
+Type query and index type query types
+=======================================
+
+type K1 = Foo[bar]
+type K1 = Foo['bar' | 'baz']
+
+---
+
+(program
+  (type_alias_declaration
+    (identifier)
+    (lookup_type (identifier) (type_identifier)))
+  (type_alias_declaration
+    (identifier)
+    (lookup_type (identifier) (union_type (literal_type (string)) (literal_type (string)))))) 

--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,9 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$.nested_type_identifier, $.member_expression],
 
     [$.generic_type, $._primary_type],
+    [$._expression, $._primary_type, $.lookup_type],
+    [$._primary_type, $.lookup_type],
+    [$.nested_identifier, $.member_expression, $.nested_type_identifier],
 
     [$.member_expression, $.nested_identifier],
 
@@ -445,7 +448,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.index_type_query,
       $.this_type,
       $.existential_type,
-      $.literal_type
+      $.literal_type,
+      $.lookup_type
     ),
 
     generic_type: $ => seq(
@@ -470,6 +474,13 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     index_type_query: $ => seq(
       'keyof',
       choice($.identifier, $.nested_identifier)
+    ),
+
+    lookup_type: $ => seq(
+      choice($.identifier, $.nested_identifier),
+      '[',
+      $._type,
+      ']'
     ),
 
     literal_type: $ => choice($.number, $.string, $.true, $.false),

--- a/grammar.js
+++ b/grammar.js
@@ -570,8 +570,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     index_signature: $ => choice(
-      seq('[', $.identifier, ':', 'string', ']', $.type_annotation),
-      seq('[', $.identifier, ':', 'number', ']', $.type_annotation)
+      seq('[', choice($.identifier, alias($._reserved_identifier, $.identifier)), ':', 'string', ']', $.type_annotation),
+      seq('[', choice($.identifier, alias($._reserved_identifier, $.identifier)), ':', 'number', ']', $.type_annotation)
     ),
 
     array_type: $ => prec.right(PREC.ARRAY_TYPE, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6779,8 +6779,22 @@
               "value": "["
             },
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_reserved_identifier"
+                  },
+                  "named": true,
+                  "value": "identifier"
+                }
+              ]
             },
             {
               "type": "STRING",
@@ -6808,8 +6822,22 @@
               "value": "["
             },
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_reserved_identifier"
+                  },
+                  "named": true,
+                  "value": "identifier"
+                }
+              ]
             },
             {
               "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6094,6 +6094,10 @@
         {
           "type": "SYMBOL",
           "name": "literal_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lookup_type"
         }
       ]
     },
@@ -6186,6 +6190,36 @@
               "name": "nested_identifier"
             }
           ]
+        }
+      ]
+    },
+    "lookup_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nested_identifier"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },
@@ -7026,6 +7060,20 @@
     [
       "generic_type",
       "_primary_type"
+    ],
+    [
+      "_expression",
+      "_primary_type",
+      "lookup_type"
+    ],
+    [
+      "_primary_type",
+      "lookup_type"
+    ],
+    [
+      "nested_identifier",
+      "member_expression",
+      "nested_type_identifier"
     ],
     [
       "member_expression",


### PR DESCRIPTION
Lookup types were added in [TypeScript 2.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html) to support what I think is type-level element access.