### PR TITLE
Negative numbers in literal types

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -381,7 +381,7 @@ let x: false
   (lexical_declaration
     (variable_declarator (identifier) (type_annotation (literal_type (number)))))
   (lexical_declaration
-    (variable_declarator (identifier) (type_annotation (union_type (union_type (literal_type (number)) (literal_type (number))) (literal_type (number))))))
+    (variable_declarator (identifier) (type_annotation (union_type (union_type (literal_type (number)) (literal_type (unary_expression (number)))) (literal_type (unary_expression (number)))))))
   (lexical_declaration
     (variable_declarator (identifier) (type_annotation (literal_type (string))))) (lexical_declaration (variable_declarator (identifier) (type_annotation (literal_type (false))))))
 

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -371,7 +371,7 @@ Literal types
 =======================================
 
 let x: 2
-let x: 2 | 3 | 4
+let x: 2 | -3 | +4
 let x: "string"
 let x: false
 

--- a/grammar.js
+++ b/grammar.js
@@ -483,7 +483,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       ']'
     ),
 
-    literal_type: $ => choice($._number, $.number, $.string, $.true, $.false),
+    literal_type: $ => choice(alias($._number, $.unary_expression), $.number, $.string, $.true, $.false),
 
     _number: $ => prec.left(PREC.NEG, seq(choice('-', '+'), $.number)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -483,7 +483,9 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       ']'
     ),
 
-    literal_type: $ => choice($.number, $.string, $.true, $.false),
+    literal_type: $ => choice(alias($._number, $.number), $.number, $.string, $.true, $.false),
+
+    _number: $ => prec.left(PREC.NEG, seq(choice('-', '+'), $.number)),
 
     existential_type: $ => '*',
 

--- a/grammar.js
+++ b/grammar.js
@@ -483,7 +483,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       ']'
     ),
 
-    literal_type: $ => choice(alias($._number, $.number), $.number, $.string, $.true, $.false),
+    literal_type: $ => choice($._number, $.number, $.string, $.true, $.false),
 
     _number: $ => prec.left(PREC.NEG, seq(choice('-', '+'), $.number)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6227,13 +6227,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_number"
-          },
-          "named": true,
-          "value": "number"
+          "type": "SYMBOL",
+          "name": "_number"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6227,8 +6227,13 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_number"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_number"
+          },
+          "named": true,
+          "value": "unary_expression"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6227,6 +6227,15 @@
       "type": "CHOICE",
       "members": [
         {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_number"
+          },
+          "named": true,
+          "value": "number"
+        },
+        {
           "type": "SYMBOL",
           "name": "number"
         },
@@ -6243,6 +6252,32 @@
           "name": "false"
         }
       ]
+    },
+    "_number": {
+      "type": "PREC_LEFT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "-"
+              },
+              {
+                "type": "STRING",
+                "value": "+"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "number"
+          }
+        ]
+      }
     },
     "existential_type": {
       "type": "STRING",


### PR DESCRIPTION
Since `-1` and `+1` are allowed as literal types, I added a `_number` term to `literal_type` so as to avoid conflicts with adding `unary_expression`. @maxbrunsfeld unfortunately this doesn’t cover the range of the signs. Any ideas?