### PR TITLE
Add support for flow class declarations with comma-separated members

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -132,6 +132,40 @@ declare module Foo {
         (catch_clause (identifier) (statement_block))
         (finally_clause (statement_block)))))))
 
+==================================================
+Flow-style ambient class declarations with commas
+==================================================
+
+declare interface IFoo {
+  bar(): number,
+  baz(): IBaz,
+}
+
+declare class Foo {
+  bar(): number,
+  baz(): Baz,
+}
+
+---
+
+(program
+  (ambient_declaration
+    (interface_declaration (identifier) (object_type
+      (method_signature
+        (property_identifier)
+        (call_signature (formal_parameters) (type_annotation (predefined_type))))
+      (method_signature
+        (property_identifier)
+        (call_signature (formal_parameters) (type_annotation (type_identifier)))))))
+  (ambient_declaration
+    (class (identifier) (class_body
+      (method_signature
+        (property_identifier)
+        (call_signature (formal_parameters) (type_annotation (predefined_type))))
+      (method_signature
+        (property_identifier)
+        (call_signature (formal_parameters) (type_annotation (type_identifier))))))))
+
 ==================================
 Ambient exports
 ==================================

--- a/grammar.js
+++ b/grammar.js
@@ -132,15 +132,13 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.call_signature
     ),
 
-
     abstract_method_signature: $ => seq(
       optional($.accessibility_modifier),
       'abstract',
       optional(choice('get', 'set', '*')),
       $._property_name,
       optional('?'),
-      $.call_signature,
-      $._semicolon
+      $.call_signature
     ),
 
     parenthesized_expression: ($, previous) => seq(
@@ -204,15 +202,19 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     class_body: ($, previous) => seq(
       '{',
-      repeat(
-        choice(
-          $.abstract_method_signature,
-          seq(repeat($.decorator), $.method_definition, optional($._semicolon)),
-          seq($.index_signature, $._semicolon),
-          seq($.method_signature, $._semicolon),
-          seq(repeat($.decorator), $.public_field_definition, $._semicolon)
+      repeat(choice(
+        $.decorator,
+        seq($.method_definition, optional($._semicolon)),
+        seq(
+          choice(
+            $.abstract_method_signature,
+            $.index_signature,
+            $.method_signature,
+            $.public_field_definition
+          ),
+          $._semicolon
         )
-      ),
+      )),
       '}'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -212,7 +212,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
             $.method_signature,
             $.public_field_definition
           ),
-          $._semicolon
+          choice($._semicolon, ',')
         )
       )),
       '}'

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4432,8 +4432,17 @@
                     ]
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_semicolon"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_semicolon"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      }
+                    ]
                   }
                 ]
               }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4384,18 +4384,11 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "abstract_method_signature"
+                "name": "decorator"
               },
               {
                 "type": "SEQ",
                 "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "decorator"
-                    }
-                  },
                   {
                     "type": "SYMBOL",
                     "name": "method_definition"
@@ -4418,41 +4411,25 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "index_signature"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_semicolon"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "method_signature"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_semicolon"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "decorator"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "public_field_definition"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "abstract_method_signature"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "index_signature"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "method_signature"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "public_field_definition"
+                      }
+                    ]
                   },
                   {
                     "type": "SYMBOL",
@@ -5199,10 +5176,6 @@
         {
           "type": "SYMBOL",
           "name": "call_signature"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_semicolon"
         }
       ]
     },


### PR DESCRIPTION
In Flow, ambient class declaration members can be separated by commas instead of semicolons. I don't think TypeScript supports this syntax, which is kind of odd, because it allows the use of commas in *object types* (e.g. `declare interface Foo {...}`) which are very similar to classes.

Here's an [example](https://github.com/flowtype/flow-typed/blob/ecf8a05bb633d293477acf0e4b191127776c96b6/definitions/npm/double-ended-queue_v2.1.x/flow_v0.28.x-/double-ended-queue_v2.1.x.js) from the `flow-typed` project.

This PR adds support for this type of class declaration.

/cc @joshvera - I simplified `class_body` a tad by allowing decorators to appear anywhere. This is more permissive than the spec, but it shrank the parser a bit and doesn't seem to do any harm.