### PR TITLE
Add script to parse examples and miscellaneous fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 *.log
 package-lock.json
 /test.ts
+/examples/desktop

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 *.log
 package-lock.json
+/test.ts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
   - npm install
 
 test_script:
-  - npm test
+  - npm run test-windows
 
 build: off
 

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -703,6 +703,7 @@ abstract class Animal {
     readonly abstract prop: string;
     static readonly prop: string;
     otherProp: string;
+    requiredProp!: string;
     abstract makeSound(): void;
     abstract get readonlyProp(): string;
     protected abstract readonlyProp?(): string;
@@ -719,6 +720,7 @@ abstract class Animal {
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type)))
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type)))
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type))) (public_field_definition (property_identifier) (type_annotation (predefined_type)))
+    (public_field_definition (property_identifier) (type_annotation (predefined_type)))
     (abstract_method_signature
       (property_identifier)
       (call_signature (formal_parameters) (type_annotation (predefined_type))))

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -70,7 +70,7 @@ declare module Foo {
   (ambient_declaration
     (lexical_declaration (variable_declarator (identifier) (string))))
   (ambient_declaration
-    (ambient_function
+    (function_signature
       (identifier)
       (call_signature
         (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
@@ -80,7 +80,7 @@ declare module Foo {
     (internal_module
       (identifier)
       (statement_block
-        (ambient_function
+        (function_signature
           (identifier)
           (call_signature
             (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
@@ -194,7 +194,7 @@ export async function readFile(filename: string): Promise<Buffer>
             (return_statement (object (shorthand_property_identifier) (shorthand_property_identifier))))))
   (comment)
   (export_statement (class (identifier) (class_body)))
-  (export_statement (ambient_function
+  (export_statement (function_signature
     (identifier)
     (call_signature
       (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
@@ -345,7 +345,7 @@ declare module "example" { }
     (variable_declaration (variable_declarator
       (identifier)
       (type_annotation (object_type))))
-    (export_statement (ambient_function
+    (export_statement (function_signature
       (identifier)
       (call_signature
         (type_parameters (type_parameter (identifier)))
@@ -445,7 +445,7 @@ export interface Foo {
       (identifier)
       (object_type
         (export_statement
-          (ambient_function
+          (function_signature
             (identifier)
             (call_signature
               (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
@@ -483,7 +483,7 @@ declare namespace moment {
       (export_statement (variable_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
       (export_statement (class (identifier) (class_body)))
       (export_statement
-        (ambient_function
+        (function_signature
           (identifier)
           (call_signature (formal_parameters) (type_annotation (type_identifier)))))
       (export_statement (enum_declaration (identifier) (enum_body

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -178,6 +178,8 @@ export default function point(x: number, y: number) {
 
 export default class A {}
 
+export async function readFile(filename: string): Promise<Buffer>
+
 ---
 
 (program
@@ -191,7 +193,12 @@ export default class A {}
           (statement_block
             (return_statement (object (shorthand_property_identifier) (shorthand_property_identifier))))))
   (comment)
-  (export_statement (class (identifier) (class_body))))
+  (export_statement (class (identifier) (class_body)))
+  (export_statement (ambient_function
+    (identifier)
+    (call_signature
+      (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))
+      (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier))))))))
 
 ==================================
 Typeof types

--- a/grammar.js
+++ b/grammar.js
@@ -164,7 +164,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       ')'
     ),
 
-    ambient_function: $ => seq(
+    function_signature: $ => seq(
       optional('async'),
       'function',
       $.identifier,
@@ -236,7 +236,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       $.export_statement,
       $.function,
       $.internal_module,
-      $.ambient_function,
+      $.function_signature,
       $.generator_function,
       $.abstract_class,
       $.class,

--- a/grammar.js
+++ b/grammar.js
@@ -75,7 +75,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
         seq(optional($.readonly), optional('abstract')),
       ),
       $._property_name,
-      optional('?'),
+      optional(choice('?', '!')),
       optional($.type_annotation),
       optional($._initializer)
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -165,6 +165,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     ),
 
     ambient_function: $ => seq(
+      optional('async'),
       'function',
       $.identifier,
       $.call_signature,

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.8.0"
+    "nan": "^2.8.0",
+    "npm": "^5.8.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.11.0",
+    "tree-sitter-cli": "^0.11.2",
     "tree-sitter-javascript": "tree-sitter/tree-sitter-javascript"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",
-    "test": "tree-sitter test && tree-sitter parse examples --quiet --time"
+    "test": "tree-sitter test && script/parse-examples",
+    "test-windows": "tree-sitter test && tree-sitter parse examples --quiet --time"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.8.0",
-    "npm": "^5.8.0"
+    "nan": "^2.8.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.11.2",

--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -1,0 +1,1 @@
+examples/desktop/app/src/lib/api.ts

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -13,7 +13,7 @@ if [ ! -d "$repo" ]; then
 fi
 
 pushd "$repo" && git pull
-git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
+# git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
 popd
 
 # TODO: Fix known issues in known_failures.txt

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -2,6 +2,20 @@
 
 set -e
 
+cd "$(dirname "$0")/.."
+
+
+# Clone desktop/desktop and check out a known sha
+repo=examples/desktop
+
+if [ ! -d "$repo" ]; then
+  git clone https://github.com/desktop/desktop "$repo"
+fi
+
+pushd "$repo" && git pull
+git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
+popd
+
 # TODO: Fix known issues in known_failures.txt
 known_failures=$(cat script/known_failures.txt)
 examples_to_parse=$(

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 cd "$(dirname "$0")/.."
 
@@ -14,7 +13,7 @@ if [ ! -d "$repo" ]; then
 fi
 
 pushd "$repo" && git pull
-# git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
+git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
 popd
 
 tree-sitter parse examples/*.ts -qt

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# TODO: Fix known issues in known_failures.txt
+known_failures=$(cat script/known_failures.txt)
+examples_to_parse=$(
+  for example in $(find examples/desktop -name '*.ts'); do
+    if [[ ! $known_failures == *$example* ]]; then
+      echo $example
+    fi
+  done
+)
+
+echo $examples_to_parse | xargs -n 5000 tree-sitter parse -q

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 cd "$(dirname "$0")/.."
 
@@ -13,7 +14,7 @@ if [ ! -d "$repo" ]; then
 fi
 
 pushd "$repo" && git pull
-git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
+# git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
 popd
 
 tree-sitter parse examples/*.ts -qt

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 cd "$(dirname "$0")/.."
 
@@ -9,13 +8,12 @@ cd "$(dirname "$0")/.."
 # Clone desktop/desktop and check out a known sha
 repo=examples/desktop
 
-rm -rf "$repo"
 if [ ! -d "$repo" ]; then
   git clone https://github.com/desktop/desktop "$repo"
 fi
 
 pushd "$repo" && git pull
-# git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
+git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
 popd
 
 tree-sitter parse examples/*.ts -qt

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -19,7 +19,7 @@ popd
 # TODO: Fix known issues in known_failures.txt
 known_failures=$(cat script/known_failures.txt)
 examples_to_parse=$(
-  for example in $(find examples/desktop -name '*.ts'); do
+  for example in $(find "$repo" -name '*.ts'); do
     if [[ ! $known_failures == *$example* ]]; then
       echo $example
     fi

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 cd "$(dirname "$0")/.."
 
@@ -8,6 +9,7 @@ cd "$(dirname "$0")/.."
 # Clone desktop/desktop and check out a known sha
 repo=examples/desktop
 
+rm -rf "$repo"
 if [ ! -d "$repo" ]; then
   git clone https://github.com/desktop/desktop "$repo"
 fi
@@ -15,6 +17,8 @@ fi
 pushd "$repo" && git pull
 # git reset --hard d1324f56d02dd9afca5d2e9da545905a7d41d671
 popd
+
+tree-sitter parse examples/*.ts -qt
 
 # TODO: Fix known issues in known_failures.txt
 known_failures=$(cat script/known_failures.txt)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4806,8 +4806,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "?"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "?"
+                },
+                {
+                  "type": "STRING",
+                  "value": "!"
+                }
+              ]
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2697,6 +2697,10 @@
                 "name": "identifier"
               },
               {
+                "type": "SYMBOL",
+                "name": "super"
+              },
+              {
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
@@ -2730,8 +2734,17 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "super"
+              }
+            ]
           },
           {
             "type": "STRING",
@@ -3960,7 +3973,7 @@
             "type": "REPEAT",
             "content": {
               "type": "PATTERN",
-              "value": "a-z"
+              "value": "[a-z]"
             }
           }
         ]
@@ -4009,6 +4022,18 @@
                       {
                         "type": "SEQ",
                         "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
                           {
                             "type": "PATTERN",
                             "value": "[1-9]"
@@ -4186,6 +4211,18 @@
                         "type": "SEQ",
                         "members": [
                           {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
                             "type": "PATTERN",
                             "value": "[1-9]"
                           },
@@ -4313,8 +4350,23 @@
       }
     },
     "identifier": {
-      "type": "PATTERN",
-      "value": "[a-zA-Z_$][a-zA-Z\\d_$]*"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\s0-9:;`\"'@#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}﻿⁠​ ]"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PATTERN",
+              "value": "[^\\s:;`\"'@#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}﻿⁠​ ]"
+            }
+          }
+        ]
+      }
     },
     "this": {
       "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5428,6 +5428,18 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "async"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "function"
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -323,7 +323,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "ambient_function"
+            "name": "function_signature"
           },
           {
             "type": "SYMBOL",
@@ -5433,7 +5433,7 @@
         }
       ]
     },
-    "ambient_function": {
+    "function_signature": {
       "type": "SEQ",
       "members": [
         {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -69,6 +69,7 @@ bool tree_sitter_typescript_external_scanner_scan(void *payload, TSLexer *lexer,
   switch (lexer->lookahead) {
     case ',':
     case '.':
+    case ';':
     case '*':
     case '%':
     case '>':


### PR DESCRIPTION
Following the work in https://github.com/tree-sitter/tree-sitter-javascript/pull/72, this updates to latest tree-sitter-javascript, adds a dedicated `script/parse-examples`, wires it up to the build and fixes a few low hanging grammar issues I found.