### PR TITLE
Differentiate type identifiers from other identifiers more consistently

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -62,7 +62,7 @@ declare module Foo {
 (program
   (ambient_declaration
     (class
-      (identifier)
+      (type_identifier)
       (class_body
         (public_field_definition (property_identifier) (type_annotation (type_identifier))))))
   (ambient_declaration
@@ -87,11 +87,11 @@ declare module Foo {
             (type_annotation (predefined_type))))
         (lexical_declaration (variable_declarator (identifier) (type_annotation (predefined_type))))
         (interface_declaration
-          (identifier)
+          (type_identifier)
           (object_type
             (property_signature (property_identifier) (type_annotation (predefined_type)))))
         (interface_declaration
-          (identifier)
+          (type_identifier)
           (object_type
             (property_signature (property_identifier) (type_annotation (predefined_type)))
             (property_signature (property_identifier) (type_annotation (predefined_type)))
@@ -99,7 +99,7 @@ declare module Foo {
 
   (ambient_declaration
     (class
-      (identifier)
+      (type_identifier)
       (class_body
         (method_signature
           (property_identifier) (call_signature (formal_parameters (required_parameter (identifier) (type_annotation (predefined_type))))))
@@ -150,7 +150,7 @@ declare class Foo {
 
 (program
   (ambient_declaration
-    (interface_declaration (identifier) (object_type
+    (interface_declaration (type_identifier) (object_type
       (method_signature
         (property_identifier)
         (call_signature (formal_parameters) (type_annotation (predefined_type))))
@@ -158,7 +158,7 @@ declare class Foo {
         (property_identifier)
         (call_signature (formal_parameters) (type_annotation (type_identifier)))))))
   (ambient_declaration
-    (class (identifier) (class_body
+    (class (type_identifier) (class_body
       (method_signature
         (property_identifier)
         (call_signature (formal_parameters) (type_annotation (predefined_type))))
@@ -193,7 +193,7 @@ export async function readFile(filename: string): Promise<Buffer>
           (statement_block
             (return_statement (object (shorthand_property_identifier) (shorthand_property_identifier))))))
   (comment)
-  (export_statement (class (identifier) (class_body)))
+  (export_statement (class (type_identifier) (class_body)))
   (export_statement (function_signature
     (identifier)
     (call_signature
@@ -213,7 +213,7 @@ declare class Linter {
 (program
   (ambient_declaration
     (class
-      (identifier)
+      (type_identifier)
       (class_body
         (public_field_definition
           (property_identifier)
@@ -289,7 +289,7 @@ export class CloningRepository {
 (program
   (export_statement
     (interface_declaration
-      (identifier)
+      (type_identifier)
       (object_type
         (property_signature
           (accessibility_modifier)
@@ -298,7 +298,7 @@ export class CloningRepository {
           (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier))))))))
   (export_statement
     (class
-      (identifier)
+      (type_identifier)
       (class_body
         (public_field_definition
         (accessibility_modifier)
@@ -316,14 +316,14 @@ declare type IndexableType = string | number | Date | Array<string | number | Da
 (program
   (ambient_declaration
     (type_alias_declaration
-      (identifier)
+      (type_identifier)
+      (union_type
         (union_type
-          (union_type
-            (union_type (predefined_type) (predefined_type))
-            (type_identifier))
-            (generic_type
-              (type_identifier)
-              (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_identifier))))))))
+          (union_type (predefined_type) (predefined_type))
+          (type_identifier))
+          (generic_type
+            (type_identifier)
+            (type_arguments (union_type (union_type (predefined_type) (predefined_type)) (type_identifier))))))))
 
 ==================================
 Ambient module declarations
@@ -442,7 +442,7 @@ export interface Foo {
 (program
   (export_statement
     (interface_declaration
-      (identifier)
+      (type_identifier)
       (object_type
         (export_statement
           (function_signature
@@ -479,9 +479,9 @@ declare namespace moment {
 (program
   (ambient_declaration
     (internal_module (identifier) (statement_block
-      (type_alias_declaration (identifier) (function_type (formal_parameters) (predefined_type)))
+      (type_alias_declaration (type_identifier) (function_type (formal_parameters) (predefined_type)))
       (export_statement (variable_declaration (variable_declarator (identifier) (type_annotation (predefined_type)))))
-      (export_statement (class (identifier) (class_body)))
+      (export_statement (class (type_identifier) (class_body)))
       (export_statement
         (function_signature
           (identifier)
@@ -507,7 +507,7 @@ declare namespace Foo {
   (ambient_declaration
     (internal_module
       (identifier)
-      (statement_block (export_statement (interface_declaration (identifier) (object_type)))))))
+      (statement_block (export_statement (interface_declaration (type_identifier) (object_type)))))))
 
 =================================
 Namespaces as internal modules
@@ -545,7 +545,7 @@ class Foo {
 (program
   (expression_statement
     (class
-      (identifier)
+      (type_identifier)
       (class_body
         (method_definition
           (accessibility_modifier)
@@ -578,7 +578,7 @@ class Foo {
 
 (program (expression_statement
   (class
-    (identifier)
+    (type_identifier)
     (class_body
       (method_signature (accessibility_modifier) (property_identifier) (call_signature (type_parameters (type_parameter (identifier))) (formal_parameters (required_parameter (identifier) (type_annotation (function_type (formal_parameters) (union_type (type_identifier) (generic_type (type_identifier) (type_arguments (union_type (type_identifier) (type_identifier)))))))) (optional_parameter (identifier) (type_annotation (function_type (formal_parameters (required_parameter (identifier) (type_annotation (type_identifier)))) (union_type (predefined_type) (generic_type (type_identifier) (type_arguments (predefined_type))))))) (optional_parameter (identifier) (type_annotation (predefined_type))) (optional_parameter (identifier) (type_annotation (predefined_type)))) (type_annotation (generic_type (type_identifier) (type_arguments (type_identifier))))))
       (method_signature (accessibility_modifier) (readonly) (property_identifier) (call_signature (type_parameters (type_parameter (identifier))) (formal_parameters)))
@@ -603,7 +603,7 @@ class Foo {
 (program
   (expression_statement
   (class
-    (identifier)
+    (type_identifier)
     (class_body
       (public_field_definition (number) (type_annotation (predefined_type)))
       (public_field_definition (accessibility_modifier) (number) (type_annotation (predefined_type)) (string))
@@ -630,7 +630,7 @@ Classes with decorators
   (class
     (decorator (identifier))
     (decorator (identifier))
-    (identifier)
+    (type_identifier)
     (class_body
       (decorator (identifier))
       (public_field_definition (number) (type_annotation (predefined_type)))
@@ -663,7 +663,7 @@ class Foo<Bar> extends Baz { bar = 5; static one(a) { return a; }; two(b) { retu
 (program
   (expression_statement
     (class
-      (identifier)
+      (type_identifier)
       (type_parameters (type_parameter (identifier)))
       (class_heritage (extends_clause (type_identifier)))
       (class_body
@@ -715,8 +715,8 @@ abstract class Animal {
 ---
 
 (program
-  (abstract_class (identifier) (class_body))
-  (abstract_class (identifier) (class_body
+  (abstract_class (type_identifier) (class_body))
+  (abstract_class (type_identifier) (class_body
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type)))
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type)))
     (public_field_definition (readonly) (property_identifier) (type_annotation (predefined_type))) (public_field_definition (property_identifier) (type_annotation (predefined_type)))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -136,7 +136,7 @@ class A extends B {
 (program
   (expression_statement
     (class
-      (identifier)
+      (type_identifier)
       (class_heritage (extends_clause (type_identifier)))
       (class_body
         (method_definition

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -181,7 +181,7 @@ type ConflictInfo = {
 
 (program
   (type_alias_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (property_signature (property_identifier) (type_annotation (type_identifier)))
       (property_signature (property_identifier) (type_annotation (type_identifier)))
@@ -189,7 +189,7 @@ type ConflictInfo = {
       (property_signature (property_identifier) (type_annotation (array_type (type_identifier))))))
 
   (type_alias_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (property_signature (property_identifier) (type_annotation (type_identifier)))
       (property_signature (property_identifier) (type_annotation (type_identifier)))
@@ -269,25 +269,25 @@ interface Enum extends Bar, Baz, funThatEvalsToInterface() {
 
 (program
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (extends_clause (type_identifier))
     (object_type (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (property_signature (property_identifier) (type_annotation (predefined_type)))
       (property_signature (property_identifier) (type_annotation (predefined_type)))))
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (type_parameters (type_parameter (identifier)) (type_parameter (identifier) (constraint (type_identifier))))
     (object_type
       (property_signature (property_identifier) (type_annotation (type_identifier)))
       (property_signature (property_identifier) (type_annotation (type_identifier)))))
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (property_signature (property_identifier) (type_annotation (object_type)))
       (method_signature
@@ -298,7 +298,7 @@ interface Enum extends Bar, Baz, funThatEvalsToInterface() {
           (type_annotation
             (generic_type (type_identifier) (type_arguments (type_identifier))))))))
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (extends_clause
       (type_identifier)
       (type_identifier)
@@ -327,11 +327,11 @@ class D extends A<
 
 (program
   (expression_statement (class
-    (identifier)
+    (type_identifier)
     (type_parameters (type_parameter (identifier)) (type_parameter (identifier)))
     (class_body)))
   (expression_statement (class
-    (identifier)
+    (type_identifier)
     (class_heritage (extends_clause (generic_type
       (type_identifier)
       (type_arguments (type_identifier) (type_identifier)))))
@@ -361,9 +361,9 @@ type Z = | "foo";
 ---
 
 (program
-  (type_alias_declaration (identifier) (union_type (predefined_type) (predefined_type)))
-  (type_alias_declaration (identifier) (union_type (union_type (literal_type (string))) (literal_type (string))))
-  (type_alias_declaration (identifier) (union_type (literal_type (string)))))
+  (type_alias_declaration (type_identifier) (union_type (predefined_type) (predefined_type)))
+  (type_alias_declaration (type_identifier) (union_type (union_type (literal_type (string))) (literal_type (string))))
+  (type_alias_declaration (type_identifier) (union_type (literal_type (string)))))
 
 =======================================
 Flow Intersection types
@@ -373,7 +373,9 @@ type BrowserStats$ResourceTiming = number & string;
 
 ---
 
-(program (type_alias_declaration (identifier) (intersection_type (predefined_type) (predefined_type))))
+(program (type_alias_declaration
+  (type_identifier)
+  (intersection_type (predefined_type) (predefined_type))))
 
 =======================================
 Flow exact object types
@@ -388,7 +390,7 @@ type BrowserStats = {|
 
 (program
   (type_alias_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (property_signature (property_identifier) (type_annotation (predefined_type)))
       (property_signature (property_identifier) (type_annotation (predefined_type))))))
@@ -423,7 +425,7 @@ type HandlerFunction<T: Element> = void
 
 (program
   (type_alias_declaration
-    (identifier)
+    (type_identifier)
     (type_parameters (type_parameter (identifier) (constraint (type_identifier))))
   (predefined_type)))
 
@@ -442,7 +444,7 @@ var y: Map<number, Promise<Map<bool, Map<Foo, Bar>>>>
 
 (program
   (interface_declaration
-    (identifier)
+    (type_identifier)
     (object_type
       (method_signature
         (property_identifier)
@@ -513,10 +515,10 @@ type K1 = typeof Person;
 
 (program
   (type_alias_declaration
-    (identifier)
-    (index_type_query (identifier)))
+    (type_identifier)
+    (index_type_query (type_identifier)))
   (type_alias_declaration
-    (identifier)
+    (type_identifier)
     (type_query (identifier))))
 
 =======================================
@@ -530,8 +532,8 @@ type K1 = Foo['bar' | 'baz']
 
 (program
   (type_alias_declaration
-    (identifier)
-    (lookup_type (identifier) (type_identifier)))
+    (type_identifier)
+    (lookup_type (type_identifier) (type_identifier)))
   (type_alias_declaration
-    (identifier)
-    (lookup_type (identifier) (union_type (literal_type (string)) (literal_type (string))))))
+    (type_identifier)
+    (lookup_type (type_identifier) (union_type (literal_type (string)) (literal_type (string))))))

--- a/grammar.js
+++ b/grammar.js
@@ -66,6 +66,10 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     [$.object, $.object_type],
   ]),
 
+  inline: ($, previous) => previous.concat([
+    $._type_identifier,
+  ]),
+
   rules: {
     public_field_definition: ($, previous) => seq(
       optional($.accessibility_modifier),
@@ -284,7 +288,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     abstract_class: ($, previous) => seq(
       'abstract',
       'class',
-      $.identifier,
+      $._type_identifier,
       optional($.type_parameters),
       optional($.class_heritage),
       $.class_body
@@ -293,7 +297,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     class: ($, previous) => seq(
       repeat($.decorator),
       'class',
-      $.identifier,
+      $._type_identifier,
       optional($.type_parameters),
       optional($.class_heritage),
       $.class_body
@@ -325,19 +329,19 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     nested_type_identifier: $ => prec(PREC.MEMBER, seq(
       choice($.identifier, $.nested_identifier),
       '.',
-      alias($.identifier, $.type_identifier)
+      $._type_identifier
     )),
 
     interface_declaration: $ => seq(
       'interface',
-      $.identifier,
+      $._type_identifier,
       optional($.type_parameters),
       optional($.extends_clause),
       $.object_type
     ),
 
     _type_reference: $ => prec(PREC.TYPE_REFERENCE, choice(
-      alias($.identifier, $.type_identifier),
+      $._type_identifier,
       $.nested_type_identifier,
       $.generic_type
     )),
@@ -372,7 +376,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     type_alias_declaration: $ => seq(
       'type',
-      $.identifier,
+      $._type_identifier,
       optional($.type_parameters),
       '=',
       $._type,
@@ -442,7 +446,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
     _primary_type: $ => choice(
       $.parenthesized_type,
       $.predefined_type,
-      alias($.identifier, $.type_identifier),
+      $._type_identifier,
       $.nested_type_identifier,
       $.generic_type,
       $.type_predicate,
@@ -460,7 +464,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     generic_type: $ => seq(
       choice(
-        alias($.identifier, $.type_identifier),
+        $._type_identifier,
         $.nested_type_identifier
       ),
       $.type_arguments
@@ -479,11 +483,11 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
 
     index_type_query: $ => seq(
       'keyof',
-      choice($.identifier, $.nested_identifier)
+      choice($._type_identifier, $.nested_type_identifier)
     ),
 
     lookup_type: $ => seq(
-      choice($.identifier, $.nested_identifier),
+      choice($._type_identifier, $.nested_type_identifier),
       '[',
       $._type,
       ']'
@@ -604,6 +608,8 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       '=>',
       $._type
     ),
+
+    _type_identifier: $ => alias($.identifier, $.type_identifier),
 
     _reserved_identifier: ($, previous) => choice(
       'declare',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2407,7 +2407,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_type_identifier"
         },
         {
           "type": "CHOICE",
@@ -5641,7 +5641,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_type_identifier"
         },
         {
           "type": "CHOICE",
@@ -5795,13 +5795,8 @@
             "value": "."
           },
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            "named": true,
-            "value": "type_identifier"
+            "type": "SYMBOL",
+            "name": "_type_identifier"
           }
         ]
       }
@@ -5815,7 +5810,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_type_identifier"
         },
         {
           "type": "CHOICE",
@@ -5854,13 +5849,8 @@
         "type": "CHOICE",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            "named": true,
-            "value": "type_identifier"
+            "type": "SYMBOL",
+            "name": "_type_identifier"
           },
           {
             "type": "SYMBOL",
@@ -6056,7 +6046,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_type_identifier"
         },
         {
           "type": "CHOICE",
@@ -6355,13 +6345,8 @@
           "name": "predefined_type"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          "named": true,
-          "value": "type_identifier"
+          "type": "SYMBOL",
+          "name": "_type_identifier"
         },
         {
           "type": "SYMBOL",
@@ -6424,13 +6409,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              "named": true,
-              "value": "type_identifier"
+              "type": "SYMBOL",
+              "name": "_type_identifier"
             },
             {
               "type": "SYMBOL",
@@ -6499,11 +6479,11 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_type_identifier"
             },
             {
               "type": "SYMBOL",
-              "name": "nested_identifier"
+              "name": "nested_type_identifier"
             }
           ]
         }
@@ -6517,11 +6497,11 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_type_identifier"
             },
             {
               "type": "SYMBOL",
-              "name": "nested_identifier"
+              "name": "nested_type_identifier"
             }
           ]
         },
@@ -7379,6 +7359,15 @@
           "name": "_type"
         }
       ]
+    },
+    "_type_identifier": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "identifier"
+      },
+      "named": true,
+      "value": "type_identifier"
     }
   },
   "extras": [
@@ -7583,6 +7572,7 @@
     "_jsx_element",
     "_jsx_attribute_name",
     "_jsx_attribute_value",
-    "_jsx_identifier"
+    "_jsx_identifier",
+    "_type_identifier"
   ]
 }


### PR DESCRIPTION
I'm evaluating Atom's TypeScript syntax highlighting, which uses this parser, and found some cases where identifiers were being highlighted as types inconsistently. We already have a `type_identifier` rule that we apply via aliases in certain cases, but this PR applies it in more cases.