### PR TITLE
Add a property sheet for syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.13.5",
+    "tree-sitter-cli": "^0.13.13",
     "tree-sitter-javascript": "tree-sitter/tree-sitter-javascript"
   },
   "scripts": {

--- a/properties/highlights.css
+++ b/properties/highlights.css
@@ -1,0 +1,38 @@
+@import "tree-sitter-javascript/properties/highlights.css";
+
+class > identifier, new_expression > call_expression > identifier {
+  scope: 'type';
+}
+
+jsx_opening_element,
+jsx_closing_element,
+jsx_self_closing_element,
+call_expression {
+  & > identifier:text('^[A-Z]') {
+    scope: 'type';
+  }
+}
+
+type_identifier,
+predefined_type {
+  scope: 'type';
+}
+
+method_signature > property_identifier,
+function_signature > identifier {
+  scope: 'function';
+}
+
+"implements",
+"namespace",
+"enum",
+"interface",
+"module",
+"declare",
+"public",
+"private",
+"protected",
+readonly,
+"type" {
+  scope: 'keyword';
+}

--- a/src/highlights.json
+++ b/src/highlights.json
@@ -1,0 +1,23000 @@
+{
+  "states": [
+    {
+      "id": 0,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 1,
+      "property_set_id": 1,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 2,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 28
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 3,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 28
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 28
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 4,
+      "property_set_id": 2,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 5,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 29
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 6,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 7,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 30
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 30
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 30
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 30
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 8,
+      "property_set_id": 3,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 9,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 28
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 10,
+      "property_set_id": 4,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 11,
+      "property_set_id": 5,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 12,
+      "property_set_id": 6,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 13,
+      "property_set_id": 7,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 14,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 31
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 31
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 15,
+      "property_set_id": 8,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 16,
+      "property_set_id": 9,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 17,
+      "property_set_id": 10,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 18,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 28
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 28
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "member_expression",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "super",
+          "named": true,
+          "state_id": 11
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 19,
+      "property_set_id": 11,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 20,
+      "property_set_id": 12,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 21,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 32
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 32
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 22,
+      "property_set_id": 13,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "${",
+          "named": false,
+          "state_id": 32
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 32
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 23,
+      "property_set_id": 14,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 24,
+      "property_set_id": 15,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 25,
+      "property_set_id": 16,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 26,
+      "property_set_id": 17,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 27,
+      "property_set_id": 18,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 28,
+      "property_set_id": 19,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 29,
+      "property_set_id": 0,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 4
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "member_expression",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "super",
+          "named": true,
+          "state_id": 11
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 30,
+      "property_set_id": 20,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 31,
+      "property_set_id": 21,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    },
+    {
+      "id": 32,
+      "property_set_id": 22,
+      "transitions": [
+        {
+          "type": "!",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "!==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "%=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&&",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "&=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "(",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": ")",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "*",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "*=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "++",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "+=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ",",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "-",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "--",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "-=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ".",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "...",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "/=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ":",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ";",
+          "named": false,
+          "state_id": 12
+        },
+        {
+          "type": "<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "<=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "==",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "===",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "=>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": ">>>=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "?",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "[",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "]",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "^",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "^=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "as",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "async",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "await",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "break",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "call_expression",
+          "named": true,
+          "state_id": 18
+        },
+        {
+          "type": "case",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "catch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "class",
+          "named": true,
+          "state_id": 6
+        },
+        {
+          "type": "class",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "comment",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "const",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "continue",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "debugger",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "declare",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "default",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "delete",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "do",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "else",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "enum",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "escape_sequence",
+          "named": true,
+          "state_id": 13
+        },
+        {
+          "type": "export",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "extends",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "false",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "finally",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "for",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "from",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "function",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "function_signature",
+          "named": true,
+          "state_id": 2
+        },
+        {
+          "type": "generator_function",
+          "named": true,
+          "state_id": 9
+        },
+        {
+          "type": "get",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "hash_bang_line",
+          "named": true,
+          "state_id": 19
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^(global|module|exports|__filename|__dirname|window|event|document|performance|screen|navigator|console)$",
+          "state_id": 20
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^require$",
+          "state_id": 11
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "identifier",
+          "named": true,
+          "state_id": 27
+        },
+        {
+          "type": "if",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "implements",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "import",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "in",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "instanceof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "interface",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "jsx_attribute",
+          "named": true,
+          "state_id": 14
+        },
+        {
+          "type": "jsx_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_expression",
+          "named": true,
+          "state_id": 21
+        },
+        {
+          "type": "jsx_opening_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "jsx_self_closing_element",
+          "named": true,
+          "state_id": 7
+        },
+        {
+          "type": "let",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "method_definition",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "method_signature",
+          "named": true,
+          "state_id": 3
+        },
+        {
+          "type": "module",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "namespace",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "new_expression",
+          "named": true,
+          "state_id": 5
+        },
+        {
+          "type": "null",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "number",
+          "named": true,
+          "state_id": 16
+        },
+        {
+          "type": "of",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "predefined_type",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "private",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "property_identifier",
+          "named": true,
+          "state_id": 15
+        },
+        {
+          "type": "protected",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "public",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "readonly",
+          "named": true,
+          "state_id": 1
+        },
+        {
+          "type": "regex",
+          "named": true,
+          "state_id": 23
+        },
+        {
+          "type": "return",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "set",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[A-Z]",
+          "state_id": 25
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "text": "^[\\$A-Z_]{2,}+$",
+          "state_id": 24
+        },
+        {
+          "type": "shorthand_property_identifier",
+          "named": true,
+          "state_id": 0
+        },
+        {
+          "type": "static",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "switch",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "template_string",
+          "named": true,
+          "state_id": 26
+        },
+        {
+          "type": "template_substitution",
+          "named": true,
+          "state_id": 22
+        },
+        {
+          "type": "throw",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "true",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "try",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "type_identifier",
+          "named": true,
+          "state_id": 4
+        },
+        {
+          "type": "typeof",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "undefined",
+          "named": true,
+          "state_id": 10
+        },
+        {
+          "type": "var",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "while",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "yield",
+          "named": false,
+          "state_id": 1
+        },
+        {
+          "type": "{",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "|",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "|=",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "||",
+          "named": false,
+          "state_id": 8
+        },
+        {
+          "type": "}",
+          "named": false,
+          "state_id": 17
+        },
+        {
+          "type": "~",
+          "named": false,
+          "state_id": 8
+        }
+      ],
+      "default_next_state_id": 0
+    }
+  ],
+  "property_sets": [
+    {},
+    {
+      "scope": "keyword"
+    },
+    {
+      "scope": "type"
+    },
+    {
+      "scope": "operator"
+    },
+    {
+      "scope": "constant.builtin"
+    },
+    {
+      "scope": "function.builtin"
+    },
+    {
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "scope": "escape"
+    },
+    {
+      "scope": "property"
+    },
+    {
+      "scope": "number"
+    },
+    {
+      "scope": "punctuation.bracket"
+    },
+    {
+      "scope": "comment"
+    },
+    {
+      "scope": "variable.builtin"
+    },
+    {
+      "scope": "embedded"
+    },
+    {
+      "scope": "string.special"
+    },
+    {
+      "scope": "constant"
+    },
+    {
+      "scope": "constructor"
+    },
+    {
+      "scope": "string"
+    },
+    {
+      "scope": "variable"
+    },
+    {
+      "scope": "function"
+    },
+    {
+      "scope": "tag"
+    },
+    {
+      "scope": "attribute"
+    },
+    {
+      "scope": "punctuation.special"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a *property sheet* to the repo that applies a `scope` property to nodes for the purposes of syntax highlighting. The current `scope` values are based on a new schema: https://github.com/tree-sitter/highlight-schema. These values are meant to be easily mappable to various theming systems, including Atom.