### PR TITLE
Support more flow import type syntax

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -148,7 +148,9 @@ Flow Import Types
 =======================================
 
 import type {UserID, User} from "./User.js";
+import {type UserID, type User} from "./User.js";
 import typeof {jimiguitar as GuitarT} from "./User.js";
+import type UserID, {addUser, removeUser} from './User.js';
 
 ---
 
@@ -158,7 +160,26 @@ import typeof {jimiguitar as GuitarT} from "./User.js";
       (named_imports (import_specifier (identifier)) (import_specifier (identifier)))) (string))
   (import_statement
     (import_clause
-      (named_imports (import_specifier (identifier) (identifier)))) (string)))
+      (named_imports (import_specifier (identifier)) (import_specifier (identifier)))) (string))
+  (import_statement
+    (import_clause
+      (named_imports (import_specifier (identifier) (identifier)))) (string))
+  (import_statement
+    (import_clause (identifier)
+      (named_imports (import_specifier (identifier)) (import_specifier (identifier)))) (string)))
+
+=======================================
+Flow Export Types
+=======================================
+
+export type UserType = {};
+export interface UserInterface {}
+
+---
+
+(program
+  (export_statement (type_alias_declaration (type_identifier) (object_type)))
+  (export_statement (interface_declaration (type_identifier) (object_type))))
 
 =======================================
 Type alias declarations

--- a/grammar.js
+++ b/grammar.js
@@ -99,6 +99,11 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       previous
     ),
 
+    _import_export_specifier: ($, previous) => seq(
+      optional(choice('type', 'typeof')),
+      previous
+    ),
+
     import_statement: $ => seq(
       'import',
       optional(choice('type', 'typeof')),

--- a/grammar.js
+++ b/grammar.js
@@ -99,7 +99,7 @@ module.exports = grammar(require('tree-sitter-javascript/grammar'), {
       previous
     ),
 
-    import_statement: ($, previous) => seq(
+    import_statement: $ => seq(
       'import',
       optional(choice('type', 'typeof')),
       choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -278,27 +278,53 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
                   "type": "STRING",
-                  "value": "as"
+                  "value": "type"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "STRING",
+                  "value": "typeof"
                 }
               ]
             },
             {
               "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "as"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adds support for `import {type Foo} from 'bar'` Flow syntax

Fixes #65 