### PR TITLE
Add mapped type support

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -39,6 +39,7 @@ module.exports = function defineGrammar(dialect) {
       [$.generic_type, $._primary_type],
       [$._expression, $._primary_type, $.lookup_type],
       [$._primary_type, $.lookup_type],
+      [$._primary_type, $.mapped_type],
 
       [$.member_expression, $.nested_identifier],
 
@@ -490,7 +491,8 @@ module.exports = function defineGrammar(dialect) {
         $.this_type,
         $.existential_type,
         $.literal_type,
-        $.lookup_type
+        $.lookup_type,
+        $.mapped_type
       ),
 
       generic_type: $ => seq(
@@ -522,6 +524,12 @@ module.exports = function defineGrammar(dialect) {
         '[',
         $._type,
         ']'
+      ),
+
+      mapped_type: $ => seq(
+        choice($._type_identifier, $.nested_type_identifier),
+        'in',
+        $._type,
       ),
 
       literal_type: $ => choice(alias($._number, $.unary_expression), $.number, $.string, $.true, $.false),
@@ -614,9 +622,11 @@ module.exports = function defineGrammar(dialect) {
 
       index_signature: $ => seq(
         '[',
-        choice($.identifier, alias($._reserved_identifier, $.identifier)),
-        ':',
-        $.predefined_type,
+        choice(seq(
+          choice($.identifier, alias($._reserved_identifier, $.identifier)),
+          ':',
+          $.predefined_type,
+        ), $.mapped_type),
         ']',
         $.type_annotation
       ),

--- a/typescript/corpus/types.txt
+++ b/typescript/corpus/types.txt
@@ -558,3 +558,25 @@ type K1 = Foo['bar' | 'baz']
   (type_alias_declaration
     (type_identifier)
     (lookup_type (type_identifier) (union_type (literal_type (string)) (literal_type (string))))))
+
+
+=======================================
+Mapped types
+=======================================
+
+export type NoInfer<T> = T & { [K in keyof T]: T[K] };
+
+---
+
+(program
+  (export_statement
+  (type_alias_declaration
+    (type_identifier)
+    (type_parameters (type_parameter (type_identifier)))
+    (intersection_type (type_identifier)
+      (object_type
+        (index_signature
+          (mapped_type
+            (type_identifier)
+            (index_type_query (type_identifier)))
+            (type_annotation (lookup_type (type_identifier) (type_identifier)))))))))

--- a/typescript/src/grammar.json
+++ b/typescript/src/grammar.json
@@ -6592,6 +6592,10 @@
         {
           "type": "SYMBOL",
           "name": "lookup_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mapped_type"
         }
       ]
     },
@@ -6709,6 +6713,32 @@
         {
           "type": "STRING",
           "value": "]"
+        }
+      ]
+    },
+    "mapped_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_type_identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nested_type_identifier"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type"
         }
       ]
     },
@@ -7327,27 +7357,41 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_reserved_identifier"
+                      },
+                      "named": true,
+                      "value": "identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "predefined_type"
+                }
+              ]
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_reserved_identifier"
-              },
-              "named": true,
-              "value": "identifier"
+              "type": "SYMBOL",
+              "name": "mapped_type"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "predefined_type"
         },
         {
           "type": "STRING",
@@ -7615,6 +7659,10 @@
     [
       "_primary_type",
       "lookup_type"
+    ],
+    [
+      "_primary_type",
+      "mapped_type"
     ],
     [
       "member_expression",


### PR DESCRIPTION
TypeScript 2.1 added support for [mapped types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html).

Resolves https://github.com/tree-sitter/tree-sitter-typescript/issues/70.