### PR TITLE
Fix native require paths in TypeScript grammar

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -1,10 +1,10 @@
 try {
-  module.exports = require("./build/Release/tree_sitter_typescript_binding");
+  module.exports = require("../build/Release/tree_sitter_typescript_binding");
 } catch (error) {
   try {
-    module.exports = require("./build/Debug/tree_sitter_typescript_binding");
+    module.exports = require("../build/Debug/tree_sitter_typescript_binding");
   } catch (_) {
-    throw error
+    throw error;
   }
 }
 


### PR DESCRIPTION
Hey @maxbrunsfeld!  Looks like native require paths for the TypeScript grammar have been broken since 0.15.2 due to commit ab9ab6c.  This PR fixes the relative path to the native module.