### PR TITLE
Allow multiline string literals as JSX attribute values.

### DIFF
--- a/tsx/corpus/expressions.txt
+++ b/tsx/corpus/expressions.txt
@@ -12,3 +12,25 @@ Type arguments in JSX
       (jsx_opening_element (identifier) (type_arguments (type_identifier)))
       (jsx_text)
       (jsx_closing_element (identifier)))))
+
+==========================================================
+TSX string literals
+==========================================================
+
+<Element attr="hello
+               world">
+</Element>;
+
+---
+
+(program
+  (expression_statement
+    (jsx_element
+      (jsx_opening_element
+        (identifier)
+        (jsx_attribute
+          (property_identifier)
+          (tsx_string)))
+      (jsx_text)
+      (jsx_closing_element
+        (identifier)))))

--- a/tsx/src/grammar.json
+++ b/tsx/src/grammar.json
@@ -2624,7 +2624,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "string"
+          "name": "tsx_string"
         },
         {
           "type": "SYMBOL",
@@ -6562,6 +6562,83 @@
         {
           "type": "STRING",
           "value": ";"
+        }
+      ]
+    },
+    "tsx_string": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC",
+                      "value": 2,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\"\\\\\\n]+|\\\\?\\r?\\n"
+                      }
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "\""
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC",
+                      "value": 2,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^'\\\\\\n]+|\\\\?\\r?\\n"
+                      }
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
         }
       ]
     },

--- a/tsx/src/node-types.json
+++ b/tsx/src/node-types.json
@@ -3283,7 +3283,7 @@
           "named": true
         },
         {
-          "type": "string",
+          "type": "tsx_string",
           "named": true
         }
       ]
@@ -5079,6 +5079,21 @@
     }
   },
   {
+    "type": "tsx_string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "tuple_type",
     "named": true,
     "fields": {},
@@ -6314,11 +6329,11 @@
   },
   {
     "type": "number",
-    "named": false
+    "named": true
   },
   {
     "type": "number",
-    "named": true
+    "named": false
   },
   {
     "type": "of",

--- a/typescript/src/grammar.json
+++ b/typescript/src/grammar.json
@@ -2620,7 +2620,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "string"
+          "name": "tsx_string"
         },
         {
           "type": "SYMBOL",
@@ -6558,6 +6558,83 @@
         {
           "type": "STRING",
           "value": ";"
+        }
+      ]
+    },
+    "tsx_string": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC",
+                      "value": 2,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\"\\\\\\n]+|\\\\?\\r?\\n"
+                      }
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "\""
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC",
+                      "value": 2,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^'\\\\\\n]+|\\\\?\\r?\\n"
+                      }
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
         }
       ]
     },

--- a/typescript/src/node-types.json
+++ b/typescript/src/node-types.json
@@ -3275,7 +3275,7 @@
           "named": true
         },
         {
-          "type": "string",
+          "type": "tsx_string",
           "named": true
         }
       ]
@@ -5068,6 +5068,21 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "tsx_string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
Typescript supports unescaped newlines within string literals used as jsx attributes, like this:
```
<a b="hello
world">
```
([same code in typescript playground](https://www.typescriptlang.org/play?#code/DwQwBARgvARAFgUwDZIPYFgBQB3VAnJAExgD4sg))

This PR adds supports for unescaped newlines in tsx attribute values.

Another, simpler solution would be to directly modify the definition of `$.string` in the javascript grammar. Having unescaped newlines in any string literal would not be legal javascript or typescript (outside of tsx attributes) but I don't see a big risk in doing so.
