### PR TITLE
Support type arguments in self-closing jsx elements.

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -75,6 +75,7 @@ module.exports = function defineGrammar(dialect) {
       .concat([
         $._type_identifier,
         $._enum_member,
+        $._jsx_start_opening_element,
       ]),
 
     rules: {
@@ -136,8 +137,7 @@ module.exports = function defineGrammar(dialect) {
         return choice(...choices);
       },
 
-      // This rule is only referenced by _expression when the dialect is 'tsx'
-      jsx_opening_element: $ => prec.dynamic(-1, seq(
+      _jsx_start_opening_element: $ => seq(
         '<',
         choice(
           field('name', choice(
@@ -152,7 +152,19 @@ module.exports = function defineGrammar(dialect) {
             field('type_arguments', optional($.type_arguments))
           )
         ),
-        repeat(field('attribute', $._jsx_attribute)),
+        repeat(field('attribute', $._jsx_attribute))
+      ),
+
+      // This rule is only referenced by _expression when the dialect is 'tsx'
+      jsx_opening_element: $ => prec.dynamic(-1, seq(
+        $._jsx_start_opening_element,
+        '>'
+      )),
+
+      // tsx only. See jsx_opening_element.
+      jsx_self_closing_element: $ => prec.dynamic(-1, seq(
+        $._jsx_start_opening_element,
+        '/',
         '>'
       )),
 

--- a/tsx/corpus/expressions.txt
+++ b/tsx/corpus/expressions.txt
@@ -3,6 +3,7 @@ Type arguments in JSX
 ==========================================================
 
 <Element<T>>hi</Element>;
+<Element<T> />;
 
 ---
 
@@ -11,4 +12,8 @@ Type arguments in JSX
     (jsx_element
       (jsx_opening_element (identifier) (type_arguments (type_identifier)))
       (jsx_text)
-      (jsx_closing_element (identifier)))))
+      (jsx_closing_element (identifier))))
+  (expression_statement
+    (jsx_self_closing_element
+       (identifier) (type_arguments (type_identifier))))
+)

--- a/tsx/src/grammar.json
+++ b/tsx/src/grammar.json
@@ -2330,79 +2330,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "<"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "name",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_jsx_identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "jsx_namespace_name"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "name",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "nested_identifier"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "type_arguments",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "type_arguments"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "FIELD",
-              "name": "attribute",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_jsx_attribute"
-              }
-            }
+            "type": "SYMBOL",
+            "name": "_jsx_start_opening_element"
           },
           {
             "type": "STRING",
@@ -2523,40 +2452,25 @@
       ]
     },
     "jsx_self_closing_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
+      "type": "PREC_DYNAMIC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
             "type": "SYMBOL",
-            "name": "_jsx_element_name"
+            "name": "_jsx_start_opening_element"
+          },
+          {
+            "type": "STRING",
+            "value": "/"
+          },
+          {
+            "type": "STRING",
+            "value": ">"
           }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "FIELD",
-            "name": "attribute",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_jsx_attribute"
-            }
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "/"
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        }
-      ]
+        ]
+      }
     },
     "_jsx_attribute": {
       "type": "CHOICE",
@@ -6565,6 +6479,86 @@
         }
       ]
     },
+    "_jsx_start_opening_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_jsx_identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "jsx_namespace_name"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "name",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "nested_identifier"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "type_arguments",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_arguments"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "FIELD",
+            "name": "attribute",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_jsx_attribute"
+            }
+          }
+        }
+      ]
+    },
     "non_null_expression": {
       "type": "PREC_LEFT",
       "value": 10,
@@ -8949,7 +8943,8 @@
     "_jsx_identifier",
     "_lhs_expression",
     "_type_identifier",
-    "ReferenceError"
+    "ReferenceError",
+    "_jsx_start_opening_element"
   ],
   "supertypes": [
     "_statement",

--- a/tsx/src/node-types.json
+++ b/tsx/src/node-types.json
@@ -3509,6 +3509,16 @@
             "named": true
           }
         ]
+      },
+      "type_arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_arguments",
+            "named": true
+          }
+        ]
       }
     }
   },

--- a/typescript/src/grammar.json
+++ b/typescript/src/grammar.json
@@ -2326,79 +2326,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "<"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "name",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_jsx_identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "jsx_namespace_name"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "name",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "nested_identifier"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "type_arguments",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "type_arguments"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "FIELD",
-              "name": "attribute",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_jsx_attribute"
-              }
-            }
+            "type": "SYMBOL",
+            "name": "_jsx_start_opening_element"
           },
           {
             "type": "STRING",
@@ -2519,40 +2448,25 @@
       ]
     },
     "jsx_self_closing_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
+      "type": "PREC_DYNAMIC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
             "type": "SYMBOL",
-            "name": "_jsx_element_name"
+            "name": "_jsx_start_opening_element"
+          },
+          {
+            "type": "STRING",
+            "value": "/"
+          },
+          {
+            "type": "STRING",
+            "value": ">"
           }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "FIELD",
-            "name": "attribute",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_jsx_attribute"
-            }
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "/"
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        }
-      ]
+        ]
+      }
     },
     "_jsx_attribute": {
       "type": "CHOICE",
@@ -6561,6 +6475,86 @@
         }
       ]
     },
+    "_jsx_start_opening_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_jsx_identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "jsx_namespace_name"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "name",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "nested_identifier"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "type_arguments",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_arguments"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "FIELD",
+            "name": "attribute",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_jsx_attribute"
+            }
+          }
+        }
+      ]
+    },
     "non_null_expression": {
       "type": "PREC_LEFT",
       "value": 10,
@@ -8945,7 +8939,8 @@
     "_jsx_identifier",
     "_lhs_expression",
     "_type_identifier",
-    "ReferenceError"
+    "ReferenceError",
+    "_jsx_start_opening_element"
   ],
   "supertypes": [
     "_statement",

--- a/typescript/src/node-types.json
+++ b/typescript/src/node-types.json
@@ -3501,6 +3501,16 @@
             "named": true
           }
         ]
+      },
+      "type_arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_arguments",
+            "named": true
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
`jsx_self_closing_element` now works just like `jsx_opening_element`, allowing an element name followed by type arguments.