### PR TITLE
Disable automatic semicolon insertion before colon

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -123,6 +123,42 @@ type Something = {
         (predefined_type)
         (type_annotation (predefined_type))))))
 
+==========================================================
+Automatic semicolon disabled before return type
+==========================================================
+
+function f(): any {
+  'a';
+  'b';
+}
+
+function
+f
+()
+ :
+ any {
+  'a'
+  'b'
+}
+
+---
+
+(program
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (type_annotation (predefined_type))
+    (statement_block
+      (expression_statement (string))
+      (expression_statement (string))))
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (type_annotation (predefined_type))
+    (statement_block
+      (expression_statement (string))
+      (expression_statement (string)))))
+
 =======================================
 Array types
 =======================================

--- a/common/scanner.h
+++ b/common/scanner.h
@@ -98,6 +98,7 @@ static inline bool external_scanner_scan(void *payload, TSLexer *lexer, const bo
       case '|':
       case '&':
       case '/':
+      case ':':
         return false;
 
       // Don't insert a semicolon before a '[' or '(', unless we're parsing


### PR DESCRIPTION
This fixes https://github.com/tree-sitter/tree-sitter-typescript/issues/93 as suggested by @maxbrunsfeld.