### PR TITLE
Refine keyof/typeof and its tests

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -639,18 +639,33 @@ const repository = foo++!
 Type query and index type query types
 =======================================
 
-type K1 = keyof Person;
-type K1 = typeof Person;
+type T = keyof Person;
+type T = keyof Person.P;
+type T = keyof Person<P>;
+
+type T = typeof Person;
+type T = typeof Person.P;
+type T = typeof Person<P>;
+
+type T = keyof typeof Person;
 
 ---
 
 (program
-  (type_alias_declaration
-    (type_identifier)
+  (type_alias_declaration (type_identifier)
     (index_type_query (type_identifier)))
-  (type_alias_declaration
-    (type_identifier)
-    (type_query (identifier))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (nested_type_identifier (identifier) (type_identifier))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (generic_type (type_identifier) (type_arguments (type_identifier)))))
+  (type_alias_declaration (type_identifier)
+    (type_query (identifier)))
+  (type_alias_declaration (type_identifier)
+    (type_query (nested_identifier (identifier) (identifier))))
+  (type_alias_declaration (type_identifier)
+    (type_query (generic_type (type_identifier) (type_arguments (type_identifier)))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (type_query (identifier)))))
 
 =======================================
 Lookup types

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -539,12 +539,12 @@ module.exports = function defineGrammar(dialect) {
 
       type_query: $ => prec(PREC.TYPEOF, seq(
         'typeof',
-        choice($.identifier, $.nested_identifier)
+        choice($.identifier, $.nested_identifier, $.generic_type)
       )),
 
       index_type_query: $ => seq(
         'keyof',
-        prec.left(PREC.DECLARATION, choice($.generic_type, $._type_identifier, $.nested_type_identifier))
+        prec.left(PREC.DECLARATION, choice($.generic_type, $._type_identifier, $.nested_type_identifier, $.type_query))
       ),
 
       lookup_type: $ => prec(PREC.ARRAY_TYPE, seq(


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/99

I'm not regenerating the parser here because #110 hasn't landed yet