### PR TITLE
Conditional types

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -639,18 +639,33 @@ const repository = foo++!
 Type query and index type query types
 =======================================
 
-type K1 = keyof Person;
-type K1 = typeof Person;
+type T = keyof Person;
+type T = keyof Person.P;
+type T = keyof Person<P>;
+
+type T = typeof Person;
+type T = typeof Person.P;
+type T = typeof Person<P>;
+
+type T = keyof typeof Person;
 
 ---
 
 (program
-  (type_alias_declaration
-    (type_identifier)
+  (type_alias_declaration (type_identifier)
     (index_type_query (type_identifier)))
-  (type_alias_declaration
-    (type_identifier)
-    (type_query (identifier))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (nested_type_identifier (identifier) (type_identifier))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (generic_type (type_identifier) (type_arguments (type_identifier)))))
+  (type_alias_declaration (type_identifier)
+    (type_query (identifier)))
+  (type_alias_declaration (type_identifier)
+    (type_query (nested_identifier (identifier) (identifier))))
+  (type_alias_declaration (type_identifier)
+    (type_query (generic_type (type_identifier) (type_arguments (type_identifier)))))
+  (type_alias_declaration (type_identifier)
+    (index_type_query (type_query (identifier)))))
 
 =======================================
 Lookup types

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -806,3 +806,25 @@ type t = readonly (readonly a[]) []
         (array_type
           (readonly)
           (type_identifier))))))
+
+==================================
+Conditional types
+==================================
+
+type T = X extends Y ? Z : Y
+type T = X extends ?Y ? ?X : Y
+
+---
+(program
+  (type_alias_declaration (type_identifier)
+    (conditional_type
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)))
+  (type_alias_declaration (type_identifier)
+    (conditional_type
+      (type_identifier)
+      (flow_maybe_type (type_identifier))
+      (flow_maybe_type (type_identifier))
+      (type_identifier))))

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -539,12 +539,12 @@ module.exports = function defineGrammar(dialect) {
 
       type_query: $ => prec(PREC.TYPEOF, seq(
         'typeof',
-        choice($.identifier, $.nested_identifier)
+        choice($.identifier, $.nested_identifier, $.generic_type)
       )),
 
       index_type_query: $ => seq(
         'keyof',
-        prec.left(PREC.DECLARATION, choice($.generic_type, $._type_identifier, $.nested_type_identifier))
+        prec.left(PREC.DECLARATION, choice($.generic_type, $._type_identifier, $.nested_type_identifier, $.type_query))
       ),
 
       lookup_type: $ => prec(PREC.ARRAY_TYPE, seq(


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/82

I chose to build this on top of https://github.com/tree-sitter/tree-sitter-typescript/pull/111, as a separate commit, so it'd also close https://github.com/tree-sitter/tree-sitter-typescript/issues/99. Note: As of writing this, I don't think there's a strict requirement between the two commits; the second commit could be extracted as a standalone PR. 