### PR TITLE
Allow "this" in type assertions

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -715,6 +715,9 @@ Assertion functions checking a type
 
 function f(x: any): asserts x is number {
 }
+class Foo<T> {
+  test(): this is T {}
+}
 
 ---
 
@@ -725,7 +728,19 @@ function f(x: any): asserts x is number {
     (required_parameter
       (identifier) (type_annotation (predefined_type))))
     (asserts (identifier) (predefined_type))
-    (statement_block)))
+    (statement_block))
+  (class_declaration
+    (type_identifier)
+    (type_parameters (type_parameter (type_identifier)))
+    (class_body
+      (method_definition
+        (property_identifier)
+        (formal_parameters)
+        (type_annotation
+          (type_predicate
+            (this)
+            (type_identifier)))
+        (statement_block)))))
 
 ==================================
 Tuple types

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -532,7 +532,7 @@ module.exports = function defineGrammar(dialect) {
       ),
 
       type_predicate: $ => seq(
-        $.identifier,
+        choice($.identifier, $.this),
         'is',
         $._type
       ),


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/96

This takes "patch-a-hole" approach from the use-case linked in the issue, but the solution might not be complete. As of writing this, I am not sure if any arbitrary type is allowed on the assertion expression's left side; I tried to learn from the following resources, but the my findings were inconclusive.

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
- https://github.com/microsoft/TypeScript/blob/d163ab67c82460b7177e7e93a3e80659a9ef75fb/src/compiler/parser.ts#L246
- https://github.com/microsoft/TypeScript/blob/d163ab67c82460b7177e7e93a3e80659a9ef75fb/src/compiler/types.ts#L2410

The trail above leads to `TypeNode`, which I couldn't find the definition of. It possibly could be a loose type which is supposed to be specialized through if assertions (IIRC the TypeScript Parser API endorses this technique), in which case the trail wouldn't end there.