### PR TITLE
Conditional types take two

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -716,6 +716,10 @@ Assertion functions checking a type
 function f(x: any): asserts x is number {
 }
 
+function isT(t: T): t is T {
+  return true
+}
+
 ---
 
 (program
@@ -724,8 +728,19 @@ function f(x: any): asserts x is number {
     (formal_parameters
     (required_parameter
       (identifier) (type_annotation (predefined_type))))
-    (asserts (identifier) (predefined_type))
-    (statement_block)))
+    (asserts (type_predicate (identifier) (predefined_type)))
+    (statement_block))
+  (function_declaration
+    (identifier)
+    (formal_parameters
+      (required_parameter
+        (identifier)
+        (type_annotation (type_identifier))))
+    (type_predicate
+      (identifier)
+      (type_identifier))
+    (statement_block (return_statement (true))))
+  )
 
 ==================================
 Tuple types

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -736,11 +736,11 @@ function isT(t: T): t is T {
       (required_parameter
         (identifier)
         (type_annotation (type_identifier))))
-    (type_predicate
-      (identifier)
-      (type_identifier))
-    (statement_block (return_statement (true))))
-  )
+    (type_predicate_annotation
+      (type_predicate
+        (identifier)
+        (type_identifier)))
+    (statement_block (return_statement (true)))))
 
 ==================================
 Tuple types

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -806,3 +806,87 @@ type t = readonly (readonly a[]) []
         (array_type
           (readonly)
           (type_identifier))))))
+
+==================================
+Conditional types
+==================================
+
+type T = X extends Y ? Z : Y
+type T = X extends ?Y ? ?X : Y
+type F<T, X, Y> = ((t: T) => X extends Y ? X : Y) extends ((t: T) => X extends Y ? Y : X) ? X : Y
+type F<T, X, Y> = (t: T) => X extends Y ? X : Y extends (t: T) => X extends Y ? Y : X ? X : Y
+
+---
+(program
+  (type_alias_declaration (type_identifier)
+    (conditional_type
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)))
+  (type_alias_declaration (type_identifier)
+    (conditional_type
+      (type_identifier)
+      (flow_maybe_type (type_identifier))
+      (flow_maybe_type (type_identifier))
+      (type_identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter (type_identifier))
+      (type_parameter (type_identifier))
+      (type_parameter (type_identifier)))
+    (conditional_type
+      (parenthesized_type
+        (function_type
+          (formal_parameters
+            (required_parameter
+              (identifier)
+              (type_annotation (type_identifier))))
+          (conditional_type
+            (type_identifier)
+            (type_identifier)
+            (type_identifier)
+            (type_identifier))))
+      (parenthesized_type
+        (function_type
+          (formal_parameters
+            (required_parameter
+              (identifier)
+              (type_annotation (type_identifier))))
+          (conditional_type
+            (type_identifier)
+            (type_identifier)
+            (type_identifier)
+            (type_identifier))))
+      (type_identifier)
+      (type_identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter (type_identifier))
+      (type_parameter (type_identifier))
+      (type_parameter (type_identifier)))
+    (function_type
+      (formal_parameters
+        (required_parameter
+          (identifier)
+          (type_annotation (type_identifier))))
+      (conditional_type
+        (conditional_type
+          (type_identifier)
+          (type_identifier)
+          (type_identifier)
+          (type_identifier))
+        (function_type
+          (formal_parameters
+            (required_parameter
+              (identifier)
+              (type_annotation (type_identifier))))
+          (conditional_type
+            (type_identifier)
+            (type_identifier)
+            (type_identifier)
+            (type_identifier)))
+        (type_identifier)
+        (type_identifier)))))

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -484,7 +484,7 @@ module.exports = function defineGrammar(dialect) {
         'asserts',
         choice(
           $.identifier,
-          seq($.identifier, 'is', $._type)
+          $.type_predicate
         )
       ),
 
@@ -510,7 +510,6 @@ module.exports = function defineGrammar(dialect) {
         $._type_identifier,
         $.nested_type_identifier,
         $.generic_type,
-        $.type_predicate,
         $.object_type,
         $.array_type,
         $.tuple_type,
@@ -629,7 +628,7 @@ module.exports = function defineGrammar(dialect) {
         field('type_parameters', optional($.type_parameters)),
         field('parameters', $.formal_parameters),
         field('return_type', optional(
-          choice($.type_annotation, $.asserts)
+          choice($.type_annotation, $.asserts, seq(':', $.type_predicate))
         ))
       ),
 

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -551,6 +551,10 @@ module.exports = function defineGrammar(dialect) {
         $._type
       ),
 
+      type_predicate_annotation: $ => seq(
+        seq(':', $.type_predicate)
+      ),
+
       type_query: $ => prec(PREC.TYPEOF, seq(
         'typeof',
         choice($.identifier, $.nested_identifier)
@@ -643,7 +647,7 @@ module.exports = function defineGrammar(dialect) {
         field('type_parameters', optional($.type_parameters)),
         field('parameters', $.formal_parameters),
         field('return_type', optional(
-          choice($.type_annotation, $.asserts, seq(':', $.type_predicate))
+          choice($.type_annotation, $.asserts, $.type_predicate_annotation)
         ))
       ),
 


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/82
enables https://github.com/tree-sitter/tree-sitter-typescript/issues/101

Given the context in https://github.com/tree-sitter/tree-sitter-typescript/pull/112#discussion_r530132836, I've taken what was described as the "second approach" of not having `type_predicate` be considered as a type (as it was previously). I think this turned out to be preferable to the previous PR since type predicate assertions are quite special and restricted in their usage.

For the conditional types and functions interplay, I'm using the following code as reference for the precedence rules.

https://www.typescriptlang.org/play?#code/C4TwDgpgBAYgPAFQDRQBooJoD4oF4oAUwAXFAgJR46pQQAewEAdgCYDOUGUA-GlKRgBQg0JFgw8sOEwCuAWwBGEAE4pZilWvlLlWYaOgBxRCnScc+IqQpU+9Rqw5deNAbQbN2hEmUq5q7g5ezpz8fC5hQiLgRoaSxuo6WhqqUIkqWEA