### PR TITLE
Fix precedence order for as_expressions

### DIFF
--- a/common/corpus/expressions.txt
+++ b/common/corpus/expressions.txt
@@ -3,11 +3,39 @@ As expressions
 ==================================
 
 h as `hello`
+T as {} & { [t: T]: T }
+T as {} & { [t: T]: T } & { [g: G]: G }
 
 ---
 
 (program
-  (expression_statement (as_expression (identifier) (template_string))))
+  (expression_statement (as_expression (identifier) (template_string)))
+  (expression_statement
+    (as_expression
+      (identifier)
+      (intersection_type
+        (object_type)
+        (object_type
+          (index_signature
+            (identifier)
+            (type_identifier)
+            (type_annotation (type_identifier)))))))
+  (expression_statement
+    (as_expression
+      (identifier)
+      (intersection_type
+        (intersection_type
+          (object_type)
+          (object_type
+            (index_signature
+              (identifier)
+              (type_identifier)
+              (type_annotation (type_identifier)))))
+        (object_type
+          (index_signature
+            (identifier)
+            (type_identifier)
+            (type_annotation (type_identifier))))))))
 
 ==================================
 Typeof expressions

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -3,6 +3,7 @@ const PREC = {
   DEFINITION: 1,
   DECLARATION: 1,
   TUPLE_TYPE: 1,
+  AS_EXPRESSION: 1,
   INTERSECTION: 2,
   UNION: 2,
   PLUS: 4,
@@ -17,7 +18,6 @@ const PREC = {
   NEW: 12,
   ARRAY_TYPE: 13,
   MEMBER: 14,
-  AS_EXPRESSION: 15,
   TYPE_ASSERTION: 16,
   TYPE_REFERENCE: 16
 };
@@ -670,7 +670,7 @@ module.exports = function defineGrammar(dialect) {
               alias($._reserved_identifier, $.identifier)
             ),
             ':',
-            $.predefined_type,
+            $._type,
           ),
           $.mapped_type_clause
         ),


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/102