### PR TITLE
Support assignment for non_null_assertion in the LHS

### DIFF
--- a/common/corpus/expressions.txt
+++ b/common/corpus/expressions.txt
@@ -118,3 +118,32 @@ Objects with reserved words as keys
   (pair key: (property_identifier) value: (true))
   (pair key: (property_identifier) value: (true))
   (pair key: (property_identifier) value: (true)))))
+
+====================================
+Assignment to non-null LHS
+====================================
+
+foo! = bar;
+foo! += bar;
+(foo)! = bar;
+(foo)! += bar;
+
+---
+(program
+  (expression_statement
+    (assignment_expression
+      (non_null_expression (identifier))
+      (identifier)))
+  (expression_statement
+    (augmented_assignment_expression
+      (non_null_expression (identifier))
+      (identifier)))
+  (expression_statement
+    (assignment_expression
+      (non_null_expression (parenthesized_expression (identifier)))
+      (identifier)))
+  (expression_statement
+    (augmented_assignment_expression
+      (non_null_expression
+        (parenthesized_expression (identifier)))
+      (identifier))))

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -114,6 +114,10 @@ module.exports = function defineGrammar(dialect) {
         field('arguments', optional($.arguments))
       )),
 
+      _augmented_assignment_lhs: ($, previous) => choice(previous, $.non_null_expression),
+
+      _lhs_expression: ($, previous) => choice(previous, $.non_null_expression),
+
       // If the dialect is regular typescript, we exclude JSX expressions and
       // include type assertions. If the dialect is TSX, we do the opposite.
       _expression: ($, previous) => {


### PR DESCRIPTION
closes https://github.com/tree-sitter/tree-sitter-typescript/issues/107

Code changes are ready. The PR is currently marked as "Draft" because it requires changes in tree-sitter-javascript (https://github.com/tree-sitter/tree-sitter-javascript/pull/146).