### PR TITLE
Tuple types enhancements - second implementation (relax E5084)

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -728,50 +728,6 @@ function f(x: any): asserts x is number {
     (statement_block)))
 
 ==================================
-Tuple types
-==================================
-
-type t = [a]
-type t = [a, b]
-type t = readonly [a, b]
-type t = [...b]
-type t = [a, ...b]
-type t = [a, b, ...c]
-type t = [a, b?]
-
----
-
-(program
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type (type_identifier)))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type (type_identifier) (type_identifier)))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type (readonly) (type_identifier) (type_identifier)))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type (rest_type (identifier))))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type
-      (type_identifier)
-      (rest_type (identifier))))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type
-      (type_identifier)
-      (type_identifier)
-      (rest_type (identifier))))
-  (type_alias_declaration
-    (type_identifier)
-    (tuple_type
-      (type_identifier)
-      (optional_tuple_type (type_identifier)))))
-
-==================================
 Read-only arrays
 ==================================
 
@@ -814,3 +770,61 @@ type t = readonly (readonly a[]) []
         (array_type
           (readonly)
           (type_identifier))))))
+
+==================================
+Tuple types
+==================================
+
+type t = []
+type t = [a, b]
+type t = readonly [a, b]
+type t = [...b]
+type t = [a, ...b]
+type t = [a, b, ...c]
+type t = [a, b?]
+type t = [a: A, b?: B, ...c: C[]]
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (identifier)
+      (identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (readonly)
+      (identifier)
+      (identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (tuple_rest_member (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (identifier) (tuple_rest_member (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (identifier)
+      (identifier)
+      (tuple_rest_member (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (identifier) (optional_tuple_type (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (labeled_tuple_type_member
+        (identifier)
+        (type_annotation (type_identifier)))
+      (labeled_tuple_type_member
+        (optional_tuple_type (identifier))
+        (type_annotation     (type_identifier)))
+      (annotated_rest_type
+        (identifier)
+        (type_annotation (array_type (type_identifier)))))))

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -803,19 +803,19 @@ type t = [a: A, b?: B, ...c: C[]]
       (identifier)))
   (type_alias_declaration
     (type_identifier)
-    (tuple_type (tuple_rest_member (identifier))))
+    (tuple_type (rest_identifier (identifier))))
   (type_alias_declaration
     (type_identifier)
-    (tuple_type (identifier) (tuple_rest_member (identifier))))
+    (tuple_type (identifier) (rest_identifier (identifier))))
   (type_alias_declaration
     (type_identifier)
     (tuple_type
       (identifier)
       (identifier)
-      (tuple_rest_member (identifier))))
+      (rest_identifier (identifier))))
   (type_alias_declaration
     (type_identifier)
-    (tuple_type (identifier) (optional_tuple_type (identifier))))
+    (tuple_type (identifier) (optional_identifier (identifier))))
   (type_alias_declaration
     (type_identifier)
     (tuple_type
@@ -823,8 +823,8 @@ type t = [a: A, b?: B, ...c: C[]]
         (identifier)
         (type_annotation (type_identifier)))
       (labeled_tuple_type_member
-        (optional_tuple_type (identifier))
+        (optional_identifier (identifier))
         (type_annotation     (type_identifier)))
-      (annotated_rest_type
-        (identifier)
+      (labeled_tuple_type_member
+        (rest_identifier (identifier))
         (type_annotation (array_type (type_identifier)))))))

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -737,6 +737,7 @@ type t = readonly [a, b]
 type t = [...b]
 type t = [a, ...b]
 type t = [a, b, ...c]
+type t = [a, b?]
 
 ---
 
@@ -763,7 +764,12 @@ type t = [a, b, ...c]
     (tuple_type
       (type_identifier)
       (type_identifier)
-      (rest_type (identifier)))))
+      (rest_type (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (type_identifier)
+      (optional_tuple_type (type_identifier)))))
 
 ==================================
 Read-only arrays

--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -734,19 +734,36 @@ Tuple types
 type t = [a]
 type t = [a, b]
 type t = readonly [a, b]
+type t = [...b]
+type t = [a, ...b]
+type t = [a, b, ...c]
 
 ---
 
 (program
-   (type_alias_declaration
-     (type_identifier)
-     (tuple_type (type_identifier)))
-   (type_alias_declaration
-     (type_identifier)
-     (tuple_type (type_identifier) (type_identifier)))
-   (type_alias_declaration
-     (type_identifier)
-     (tuple_type (readonly) (type_identifier) (type_identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (type_identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (type_identifier) (type_identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (readonly) (type_identifier) (type_identifier)))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type (rest_type (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (type_identifier)
+      (rest_type (identifier))))
+  (type_alias_declaration
+    (type_identifier)
+    (tuple_type
+      (type_identifier)
+      (type_identifier)
+      (rest_type (identifier)))))
 
 ==================================
 Read-only arrays

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -68,6 +68,8 @@ module.exports = function defineGrammar(dialect) {
       [$._expression, $.predefined_type],
       [$._expression, $._rest_annotation],
 
+      [$._tuple_type, $.tuple_type],
+
       [$.object, $.object_type],
       [$.object, $._property_name],
     ]),
@@ -501,6 +503,10 @@ module.exports = function defineGrammar(dialect) {
         $.constructor_type
       ),
 
+      optional_tuple_type: $ => seq($._type, '?'),
+
+      _tuple_type: $ => choice($.optional_tuple_type, $._type),
+
       constructor_type: $ => seq(
         'new',
         optional($.type_parameters),
@@ -694,9 +700,9 @@ module.exports = function defineGrammar(dialect) {
           '[',
           choice(
             $.rest_type,
-            seq($._type, optional(seq(',', $.rest_type))),
-            seq($._type, optional(repeat(seq(',', $._type)))),
-            seq($._type, repeat(seq(',', $._type)), optional(seq(',', $.rest_type))),
+            seq($._tuple_type, optional(seq(',', $.rest_type))),
+            seq($._tuple_type, optional(repeat(seq(',', $._tuple_type)))),
+            seq($._tuple_type, repeat(seq(',', $._tuple_type)), optional(seq(',', $.rest_type))),
           ),
           ']'
         ))

--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -67,13 +67,12 @@ module.exports = function defineGrammar(dialect) {
       [$._expression, $.generic_type],
       [$._expression, $.predefined_type],
       [$._expression, $._rest_identifier],
-      [$._expression, $._tuple_type_member_type],
-      [$._expression, $.optional_tuple_type],
+      [$._expression, $._tuple_type_identifier],
+      [$._expression, $.optional_identifier],
 
       [$.object, $.object_type],
       [$.object, $._property_name],
 
-      [$._tuple_type_member_type, $.optional_tuple_type],
       [$.array, $._tuple_type_body]
     ]),
 
@@ -482,14 +481,11 @@ module.exports = function defineGrammar(dialect) {
         $.identifier,
       ),
 
+      rest_identifier: $ => $._rest_identifier,
+
       rest_parameter: $ => seq(
         $._rest_identifier,
         optional($.type_annotation)
-      ),
-
-      annotated_rest_type: $ => seq(
-        $._rest_identifier,
-        $.type_annotation
       ),
 
       type_annotation: $ => seq(':', $._type),
@@ -511,19 +507,19 @@ module.exports = function defineGrammar(dialect) {
         $.constructor_type
       ),
 
-      tuple_rest_member: $ => $._rest_identifier,
+      optional_identifier: $ => seq($.identifier, '?'),
 
-      optional_tuple_type: $ => seq($.identifier, '?'),
+      _tuple_type_identifier: $ => choice(
+        $.identifier,
+        $.optional_identifier,
+        $.rest_identifier
+      ),
 
-      _tuple_type_member_type: $ => choice($.optional_tuple_type, $.identifier),
-
-      labeled_tuple_type_member: $ => seq($._tuple_type_member_type, $.type_annotation),
+      labeled_tuple_type_member: $ => seq($._tuple_type_identifier, $.type_annotation),
 
       _tuple_type_member: $ => choice(
-        $._tuple_type_member_type,
-        $.tuple_rest_member,
+        $._tuple_type_identifier,
         $.labeled_tuple_type_member,
-        $.annotated_rest_type
       ),
 
       constructor_type: $ => seq(


### PR DESCRIPTION
Workaround for E5084

```Tuple members must all have names or all not have names. (5084)```

Incited by comment https://github.com/tree-sitter/tree-sitter-typescript/pull/118#discussion_r532865757

src/parser.c

```
#define STATE_COUNT 3133
#define LARGE_STATE_COUNT 636
```