### PR TITLE
Remove Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-
-node_js:
-  - "10"
-
-branches:
-  only:
-    - master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 tree-sitter-typescript
 ===========================
 
-[![Build Status](https://travis-ci.org/tree-sitter/tree-sitter-typescript.svg?branch=master)](https://travis-ci.org/tree-sitter/tree-sitter-typescript)
 [![Build status](https://ci.appveyor.com/api/projects/status/rn11gs5y3tm7tuy0/branch/master?svg=true)](https://ci.appveyor.com/project/maxbrunsfeld/tree-sitter-typescript/branch/master)
 
 TypeScript and TSX grammars for [tree-sitter][].


### PR DESCRIPTION
Travis no longer supports open-source projects and all builds just times out because there is no server capacity. 

So just remove it. 