### PR TITLE
Add Rust package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Cargo.lock
 node_modules
 .node-version
 build
@@ -6,3 +7,4 @@ package-lock.json
 /test.ts
 examples/desktop
 examples/redux
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "bindings/rust/typescript",
+    "bindings/rust/tsx",
+]

--- a/bindings/rust/tsx/Cargo.toml
+++ b/bindings/rust/tsx/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tree-sitter-tsx"
+description = "Tsx grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tsx"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-tsx"
+edition = "2018"
+
+build = "src/build.rs"
+include = [
+  "./*",
+  "../../../tsx/grammar.js",
+  "../../../queries/*",
+  "../../../tsx/src/*",
+]
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tree-sitter = "0.17"
+
+[build-dependencies]
+cc = "1.0"

--- a/bindings/rust/tsx/README.md
+++ b/bindings/rust/tsx/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-tsx
+
+This crate provides a Tsx grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-tsx = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    function double(x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_tsx::language()).expect("Error loading Tsx grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-tsx/*/tree_sitter_tsx/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/tsx/src/build.rs
+++ b/bindings/rust/tsx/src/build.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("../../../tsx/src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser-scanner");
+}

--- a/bindings/rust/tsx/src/lib.rs
+++ b/bindings/rust/tsx/src/lib.rs
@@ -1,0 +1,72 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter-tsx authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Tsx grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     function double(x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_tsx::language()).expect("Error loading Tsx grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_tsx() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_tsx() }
+}
+
+/// The source of the Tsx tree-sitter grammar description.
+pub const GRAMMAR: &str = include_str!("../../../../tsx/grammar.js");
+
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &str = include_str!("../../../../queries/highlights.scm");
+
+/// The local-variable syntax highlighting query for this language.
+pub const LOCALS_QUERY: &str = include_str!("../../../../queries/locals.scm");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &str = include_str!("../../../../tsx/src/node-types.json");
+
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &str = include_str!("../../../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Tsx grammar");
+    }
+}

--- a/bindings/rust/typescript/Cargo.toml
+++ b/bindings/rust/typescript/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tree-sitter-typescript"
+description = "TypeScript grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "typescript"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-typescript"
+edition = "2018"
+
+build = "src/build.rs"
+include = [
+  "./*",
+  "../../../typescript/grammar.js",
+  "../../../queries/*",
+  "../../../typescript/src/*",
+]
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tree-sitter = "0.17"
+
+[build-dependencies]
+cc = "1.0"

--- a/bindings/rust/typescript/README.md
+++ b/bindings/rust/typescript/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-typescript
+
+This crate provides a TypeScript grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-typescript = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    function double(x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_typescript::language()).expect("Error loading TypeScript grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-typescript/*/tree_sitter_typescript/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/typescript/src/build.rs
+++ b/bindings/rust/typescript/src/build.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("../../../typescript/src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser-scanner");
+}

--- a/bindings/rust/typescript/src/lib.rs
+++ b/bindings/rust/typescript/src/lib.rs
@@ -1,0 +1,72 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter-typescript authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a TypeScript grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     function double(x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_typescript::language()).expect("Error loading TypeScript grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_typescript() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_typescript() }
+}
+
+/// The source of the TypeScript tree-sitter grammar description.
+pub const GRAMMAR: &str = include_str!("../../../../typescript/grammar.js");
+
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &str = include_str!("../../../../queries/highlights.scm");
+
+/// The local-variable syntax highlighting query for this language.
+pub const LOCALS_QUERY: &str = include_str!("../../../../queries/locals.scm");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &str = include_str!("../../../../typescript/src/node-types.json");
+
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &str = include_str!("../../../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading TypeScript grammar");
+    }
+}


### PR DESCRIPTION
This PR adds a `Rust` package for `tree-sitter-tsx` and `tree-sitter-typescript` grammars. 

This makes it easier to use the Rust tree-sitter bindings with a statically known set of languages, since you can just list them as normal `Rust` dependencies, instead of having to embed the grammar and set up a `build.rs` file yourself.

Thanks in advance for your review! :)