### PR TITLE
Disable automatic semicolon insertion at end of object patterns

### DIFF
--- a/common/corpus/types.txt
+++ b/common/corpus/types.txt
@@ -21,13 +21,20 @@ Parenthesized types
 =======================================
 
 var x: (string);
+var x: ({a: any});
 
 ---
 
 (program
   (variable_declaration (variable_declarator
     (identifier)
-    (type_annotation (parenthesized_type (predefined_type))))))
+    (type_annotation (parenthesized_type (predefined_type)))))
+  (variable_declaration (variable_declarator
+    (identifier)
+    (type_annotation (parenthesized_type
+      (object_type
+        (property_signature (property_identifier) (type_annotation (predefined_type))))))))
+)
 
 =======================================
 Object types
@@ -225,6 +232,26 @@ const foo: (this: Readable, size?: number) => any;
           (required_parameter (this) (type_annotation (type_identifier)))
           (optional_parameter (identifier) (type_annotation (predefined_type))))
         (predefined_type))))))
+
+======================================
+Functions with destructured parameters
+======================================
+
+let foo: ({a}: Foo) => number
+
+---
+
+(program
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (type_annotation
+        (function_type
+          (formal_parameters
+            (required_parameter
+              (object_pattern (shorthand_property_identifier_pattern))
+              (type_annotation (type_identifier))))
+          (predefined_type))))))
 
 =======================================
 Constructor types

--- a/common/scanner.h
+++ b/common/scanner.h
@@ -78,7 +78,17 @@ static inline bool external_scanner_scan(void *payload, TSLexer *lexer, const bo
 
     for (;;) {
       if (lexer->lookahead == 0) return true;
-      if (lexer->lookahead == '}') return true;
+      if (lexer->lookahead == '}') {
+        // Automatic semicolon insertion breaks detection of object patterns
+        // in a typed context:
+        //   type F = ({a}: {a: number}) => number;
+        // Therefore, disable automatic semicolons when followed by typing
+        do {
+          advance(lexer);
+        } while (iswspace(lexer->lookahead));
+        if (lexer->lookahead == ':') return false;
+        return true;
+      }
       if (!iswspace(lexer->lookahead)) return false;
       if (lexer->lookahead == '\n') break;
       advance(lexer);


### PR DESCRIPTION
"object_type" nodes admit automatic semicolons, whereas "object_pattern"
nodes do not. The current grammar will greedily attempt to consume an
object_type node, and insert an automatic semicolon within this type:

  ({a}: {a: number}) => number

Since object types can never themselves be typed, I use two-token
lookahead when deciding to insert an automatic semicolon before the
closing braces of a braced sequence of tokens; if a type annotation
follows the closing brace, we will not allow an automatic semicolon.

Fixes https://github.com/tree-sitter/tree-sitter-typescript/issues/144.