### PR TITLE
Use GHA on all pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: build
 on:
   push:
   pull_request:
-    branches:
-      - '**:**'
 
 jobs:
   build:


### PR DESCRIPTION
This was previously configured to use a branch pattern that
would only match illegal branch names.