### PR TITLE
0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-typescript"
 description = "Typescript grammar for the tree-sitter parsing library"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "README.md"
@@ -25,7 +25,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-typescript",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Typescript grammar for tree-sitter",
   "keywords": [
     "parser",
@@ -18,7 +18,7 @@
   },
   "main": "./bindings/node",
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.3",
+    "tree-sitter-cli": "^0.20.0",
     "tree-sitter-javascript": "github:tree-sitter/tree-sitter-javascript#2c5b138"
   },
   "scripts": {


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).

This PR updates `tree-sitter-typescript` to 0.20

@maxbrunsfeld 

Can we release it on crates.io also? Thanks in advance! :)
