### PR TITLE
Add a CI step that checks whether the generated files are up-to-date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,10 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build and check generated files
+        run: |
+          npm run build
+          script/check-generated-files
+
       - name: Test corpus & parse examples
         run: npm test

--- a/script/check-generated-files
+++ b/script/check-generated-files
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if ! git diff-index --quiet HEAD -- {tsx,typescript}/src/; then
+    cat 1>&2 <<EOF
+Generated files in the working tree are inconsistent with HEAD.
+Make sure to commit generated files in {tsx,typescript}/src/ when the grammar changes.
+EOF
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR adds a step to the build workflow that builds the grammar and checks if the generated files change w.r.t. to the files in HEAD.

The goal is to prevent problems when the grammar is updated but the generated files are forgotten, which causes invalid tests results as these are ran using the generated files.
By running `npm run build` in the workflow and checking that the generated files in HEAD are the same as the ones produced by the CI build, we prevent inconsistencies between grammar and generated files.

I have tested this locally using `act`, but I should note that I do not have a lot of experience with workflows.

This should prevent issues like #193 in the future.
