### PR TITLE
Fix build reproducability and CI check

### DIFF
--- a/script/check-generated-files
+++ b/script/check-generated-files
@@ -2,11 +2,17 @@
 
 set -eu
 
-if ! git diff-index --quiet HEAD -- {tsx,typescript}/src/; then
-    cat 1>&2 <<EOF
-Generated files in the working tree are inconsistent with HEAD.
-Make sure to commit generated files in {tsx,typescript}/src/ when the grammar changes.
-EOF
+## Update index to make sure the subsequent diff-index command only reports
+## a change if the file content actually changed. Not updating the index can
+## give incorrect results when this script is run right after a build.
+
+git update-index -q --really-refresh
+
+if ! git diff-index --exit-code --name-status HEAD -- {tsx,typescript}/src/; then
+    echo "The following files are not up to date in the repository:" 1>&2
+    git diff-index --name-status HEAD 1>&2
+    echo "Run a build and commit the generated files to resolve this issue." 1>&2
+    git diff-index -p HEAD
     exit 1
 fi
 


### PR DESCRIPTION
This PR fixes two issues concerning builds and CI.

1. A bug in `script/check-generated-files` that would cause the build to fail, even though files were not actually changed. The fix was to update the index before running the diff command.

2. ~Add lock files to the repository, so that the CI build is run with exactly the same package versions as a local build. Without this, the CI build will always use the latest allowed version, which my produce different results from the local build. With the lock files in the repository, builds become predictable and problems because of accidental differences between CI and local environments are reduced. Updating packages becomes an explicit action: run `npm update` and commit the updated lock files.~