### PR TITLE
Document why module block is optional

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -479,6 +479,8 @@ module.exports = function defineGrammar(dialect) {
 
       _module: $ => prec.right(seq(
         field('name', choice($.string, $.identifier, $.nested_identifier)),
+        // On .d.ts files "declare module foo" desugars to "declare module foo {}",
+        // hence why it is optional here
         field('body', optional($.statement_block))
       )),
 


### PR DESCRIPTION

Checklist:
- [ ] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).

close #198
