### PR TITLE
Fix empty range for ternary question mark

### DIFF
--- a/common/scanner.h
+++ b/common/scanner.h
@@ -172,18 +172,18 @@ static bool scan_ternary_qmark(TSLexer *lexer) {
     /* Optional chaining. */
     if (lexer->lookahead == '.') return false;
 
+    lexer->mark_end(lexer);
+    lexer->result_symbol = TERNARY_QMARK;
+
     /* TypeScript optional arguments contain the ?: sequence, possibly
        with whitespace. */
     for(;;) {
       if (!iswspace(lexer->lookahead)) break;
-      skip(lexer);
+      advance(lexer);
     }
     if (lexer->lookahead == ':') return false;
     if (lexer->lookahead == ')') return false;
     if (lexer->lookahead == ',') return false;
-
-    lexer->mark_end(lexer);
-    lexer->result_symbol = TERNARY_QMARK;
 
     if (lexer->lookahead == '.') {
       advance(lexer);


### PR DESCRIPTION
skip() was used after the qmark token has been read, which resets the start position of the token:
https://github.com/tree-sitter/tree-sitter/blob/9df064c9fe31d35dc48244a6675588aee2d61a41/lib/src/lexer.c#L184

I also moved the mark_end earlier such that the qmark token does not include trailing whitespace in its range.

One could argue that the behavior of advance(skip=true) in tree-sitter should be changed instead but I'm not sure about the implications for other external parsers. (E.g., make it so that the start_position is only moved up during advance(skip=true) if no mark_end call has occurred yet).

Fixes https://github.com/tree-sitter/tree-sitter-typescript/issues/200
As pointed out in the issue and also to my knowledge, there is currently no simple way to provide automated tests for this change, or is there?

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
