### PR TITLE
Release version 0.20.2

### DIFF
--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -1,0 +1,34 @@
+name: Publish on crates.io
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Verify publish crate
+        run: cargo publish --dry-run
+
+      - name: Publish crate
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-typescript"
 description = "Typescript grammar for the tree-sitter parsing library"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-typescript",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Typescript grammar for tree-sitter",
   "keywords": [
     "parser",


### PR DESCRIPTION
This PR bumps the version to 0.20.2 to enable a new release. It also adds an action to automatically publish a new crate when a version tag is pushed.

Because the discussion regarding version schemes has not yet been resolved (partly due to my own lack of effort), I have chosen to stick for now with the current convention of staying on the tree-sitter version, and increment the patch version only.