### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .node-version
 target
 build
+/.build
 *.log
 Cargo.lock
 package-lock.json

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterTypeScript",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [.library(name: "TreeSitterTypeScript", targets: ["TreeSitterTypeScript"])],
+    targets: [
+        .target(
+            name: "TreeSitterTypeScript",
+            path: ".",
+            exclude: [
+            ],
+            sources: [
+                "typescript/src/parser.c",
+                "typescript/src/scanner.c",
+                "tsx/src/parser.c",
+                "tsx/src/scanner.c",
+            ],
+            resources: [
+                .copy("queries"),
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("typescript/src")]
+        ),
+    ]
+)

--- a/bindings/swift/TreeSitterTypeScript/typescript.h
+++ b/bindings/swift/TreeSitterTypeScript/typescript.h
@@ -1,0 +1,17 @@
+#ifndef TREE_SITTER_TYPESCRIPT_H_
+#define TREE_SITTER_TYPESCRIPT_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_typescript();
+extern TSLanguage *tree_sitter_tsx();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_TYPESCRIPT_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. This should require no maintenance on your part, and should not impact the actual parsers in any way. Other similar changes were made here:

https://github.com/tree-sitter/tree-sitter-go
https://github.com/tree-sitter/tree-sitter-c
https://github.com/tree-sitter/tree-sitter-haskell

This one is a little special, because of the two parsers. At first, I thought I could use a similar approach to https://github.com/MDeiml/tree-sitter-markdown, which also has two. However, the project is structured in a way that SPM cannot quite handle (the gitignores for the sub directories in particular). So, I just combined the two parsers into one single static lib target. I suppose this adds a binary size penalty for someone that only wanted one of the dialects. But I'm unsure how to address it without project layout changes and I just don't know if that's worth it.
