### PR TITLE
fix: add alias for nested_identifiers from javascript grammar

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -237,7 +237,7 @@ module.exports = function defineGrammar(dialect) {
               seq(
                 field('name', choice(
                   $.identifier,
-                  $.nested_identifier
+                  alias($.nested_identifier, $.member_expression),
                 )),
                 field('type_arguments', optional($.type_arguments))
               )

--- a/tsx/src/grammar.json
+++ b/tsx/src/grammar.json
@@ -7230,8 +7230,13 @@
                                 "name": "identifier"
                               },
                               {
-                                "type": "SYMBOL",
-                                "name": "nested_identifier"
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "nested_identifier"
+                                },
+                                "named": true,
+                                "value": "member_expression"
                               }
                             ]
                           }

--- a/tsx/src/node-types.json
+++ b/tsx/src/node-types.json
@@ -3412,7 +3412,7 @@
             "named": true
           },
           {
-            "type": "nested_identifier",
+            "type": "member_expression",
             "named": true
           }
         ]
@@ -3460,7 +3460,7 @@
             "named": true
           },
           {
-            "type": "nested_identifier",
+            "type": "member_expression",
             "named": true
           }
         ]

--- a/typescript/src/grammar.json
+++ b/typescript/src/grammar.json
@@ -7230,8 +7230,13 @@
                                 "name": "identifier"
                               },
                               {
-                                "type": "SYMBOL",
-                                "name": "nested_identifier"
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "nested_identifier"
+                                },
+                                "named": true,
+                                "value": "member_expression"
                               }
                             ]
                           }

--- a/typescript/src/node-types.json
+++ b/typescript/src/node-types.json
@@ -3408,7 +3408,7 @@
             "named": true
           },
           {
-            "type": "nested_identifier",
+            "type": "member_expression",
             "named": true
           }
         ]
@@ -3456,7 +3456,7 @@
             "named": true
           },
           {
-            "type": "nested_identifier",
+            "type": "member_expression",
             "named": true
           }
         ]


### PR DESCRIPTION
This will keep query compatibility with javascript

Ping @guillaumebrunerie for reference since they're related to your recent changes

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
