### PR TITLE
Update highlights.scm for content_tag

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -33,3 +33,7 @@
   "override"
   "satisfies"
 ] @keyword
+
+; Sub-language delimeters
+(glimmer_opening_tag) @tag.builtin
+(glimmer_closing_tag) @tag.builtin


### PR DESCRIPTION
Updates the surrounding tokens for content-tag, `<template>` (the entirety of the contents here are passed to a sub-language, glimmer in this case in the screenshots)


Before:
![image](https://github.com/tree-sitter/tree-sitter-javascript/assets/199018/d0ef8114-9ee5-4bac-8788-29c664183699)

After: 
![image](https://github.com/tree-sitter/tree-sitter-javascript/assets/199018/d3d15a28-24a9-43d1-babb-507bad671b73)


Info on content_tag:
- Rust Parser: https://github.com/embroider-build/content-tag/
- Spec: https://wycats.github.io/polaris-sketchwork/content-tag.html


# Checklist

- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
