### PR TITLE
[fix] Wrongly tagging PascalCase symbols as types

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -3,9 +3,6 @@
 (type_identifier) @type
 (predefined_type) @type.builtin
 
-((identifier) @type
- (#match? @type "^[A-Z]"))
-
 (type_arguments
   "<" @punctuation.bracket
   ">" @punctuation.bracket)


### PR DESCRIPTION
# Reasoning
Enums, Class names, constants, and anything using `PascalCase` was tagged as `Type`, which in most cases is not the case. 

Typescript's documentation suggests that things like [Enums](https://www.typescriptlang.org/docs/handbook/enums.html) should be `PascalCase`, and it's how they write their docs examples and also the code that is exposed to users.
There are also some cases, where a `const` can be used to replace an enum, like:

```ts
const Priorities = {
  Max: 1000,
  Mid: 500,
  low: 100,
};
```

![image](https://github.com/tree-sitter/tree-sitter-typescript/assets/4634613/1ef99ca7-063d-4ebf-84b8-827eb991e9c7)

For the other cases, like `type` and `interface`, they are already covered the `type_identifier` on line `3`.

![image](https://github.com/tree-sitter/tree-sitter-typescript/assets/4634613/d28befa4-dcb4-41ca-ac48-ee879221fb7b)



# Checklist

- [x] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
