### PR TITLE
Support single-file executables via `bun build --compile`

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,6 +1,10 @@
 const root = require("path").join(__dirname, "..", "..");
 
-module.exports = require("node-gyp-build")(root);
+module.exports =
+  typeof process.versions.bun === "string"
+    // Support `bun build --compile` by being statically analyzable enough to find the .node file at build-time
+    ? require(`../../prebuilds/${process.platform}-${process.arch}/tree-sitter-typescript.node`)
+    : require("node-gyp-build")(root);
 
 try {
   module.exports.typescript.nodeTypeInfo = require("../../typescript/src/node-types.json");


### PR DESCRIPTION
This unblocks using `tree-sitter-typescript` in [single-file executables](https://bun.sh/docs/bundler/executables)

This is the same as https://github.com/tree-sitter/node-tree-sitter/pull/230, except specifically for `tree-sitter-typescript` instead of `tree-sitter`.

`node-gyp-build` performs runtime checks for figuring out where the `.node` file is, but those runtime checks are difficult for static analysis to figure out where the `.node` file is. If we can rely on the prebuild to exist, we can use a template string and Bun will inline the `process.platform`, `process.arch`, and `process.versions.bun` fields within `--compile`.

Related PRs:
- https://github.com/tree-sitter/node-tree-sitter/pull/230
- https://github.com/oven-sh/bun/pull/14940
- https://github.com/oven-sh/bun/pull/14935
- https://github.com/oven-sh/bun/pull/14915


