### PR TITLE
Fix parsing of instantiation expressions with template literals

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -177,7 +177,7 @@ module.exports = function defineGrammar(dialect) {
           field('arguments', $.arguments),
         )),
         prec('template_call', seq(
-          field('function', choice($.primary_expression, $.new_expression)),
+          field('function', choice($.primary_expression, $.new_expression, $.instantiation_expression)),
           field('arguments', $.template_string),
         )),
         prec('member', seq(


### PR DESCRIPTION
## Problem

Fixes #329

The parser was inconsistently handling code containing instantiation expressions followed by template literals (e.g., `` sql<never[]>`'[]'` ``). Removing certain lines from the code would cause the entire file to fail parsing, while keeping those lines would result in successful parsing with only minor warnings.

## Root Cause

The issue was in the `call_expression` rule for template calls in `/common/define-grammar.js`. The template call rule only allowed `primary_expression` or `new_expression` as the function, but `sql<never[]>` is an `instantiation_expression`, which wasn't included in the allowed choices.

## Solution

Modified the template call rule to include `$.instantiation_expression`:

```javascript
// Before:
prec('template_call', seq(
  field('function', choice($.primary_expression, $.new_expression)),
  field('arguments', $.template_string),
)),

// After:
prec('template_call', seq(
  field('function', choice($.primary_expression, $.new_expression, $.instantiation_expression)),
  field('arguments', $.template_string),
)),
```
