### PR TITLE
dev: base `make` on sources, use project-local TS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TS ?= tree-sitter
+TS ?= npx tree-sitter
 
 all install uninstall clean:
 	$(MAKE) -C typescript $@

--- a/common/common.mak
+++ b/common/common.mak
@@ -8,7 +8,7 @@ VERSION := 0.23.2
 # repository
 SRC_DIR := src
 
-TS ?= tree-sitter
+TS ?= npx tree-sitter
 
 # install directory layout
 PREFIX ?= /usr/local
@@ -64,8 +64,8 @@ $(LANGUAGE_NAME).pc: ../bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@CMAKE_PROJECT_HOMEPAGE_URL@|$(HOMEPAGE_URL)|' \
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
-$(PARSER): $(SRC_DIR)/grammar.json
-	$(TS) generate $^
+$(PARSER): grammar.js ../common/define-grammar.js
+	$(TS) generate
 
 install: all
 	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'


### PR DESCRIPTION
Two Makefile improvements to spare newcomers like me some stumbles :)

1. Default `TS` to `npx tree-sitter` instead of `tree-sitter`, to use the tree-sitter CLI version pinned in the project rather than whatever global binary happens to be on `$PATH` (which could result in arbitrary unrelated diffs in the generated parser)

2. Change the Make rule for parser generation to depend on the actual sources `grammar.js` and `../common/define-grammar.js` rather than the derived file `src/grammar.json`, so that editing a grammar source and running `make` regenerates `src/grammar.json` before regenerating the parser.